### PR TITLE
fix groupname label

### DIFF
--- a/msft-operator/ray-operator/controllers/common/pod.go
+++ b/msft-operator/ray-operator/controllers/common/pod.go
@@ -42,7 +42,7 @@ func DefaultHeadPodConfig(instance rayiov1alpha1.RayCluster, rayNodeType rayiov1
 	if pConfig.podTemplate.Labels == nil {
 		pConfig.podTemplate.Labels = make(map[string]string)
 	}
-	pConfig.podTemplate.Labels = labelPod(string(rayiov1alpha1.HeadNode), instance.Name, "headGroup", instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
+	pConfig.podTemplate.Labels = labelPod(string(rayiov1alpha1.HeadNode), instance.Name, "headgroup", instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
 
 	if pConfig.podTemplate.ObjectMeta.Namespace == "" {
 		pConfig.podTemplate.ObjectMeta.Namespace = instance.Namespace


### PR DESCRIPTION
groupname was set to headGroup instead of headgroup (lowercase)