### PR TITLE
allow deletion of workers

### DIFF
--- a/msft-operator/ray-operator/.gitignore
+++ b/msft-operator/ray-operator/.gitignore
@@ -44,5 +44,8 @@ vendor/
 # Project related ignores
 /ray-operator
 
+*.vscode
+__debug_bin
+
 config/manager/my-kustomization.yaml
 config/manager/my-manager.yaml

--- a/msft-operator/ray-operator/Makefile
+++ b/msft-operator/ray-operator/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ray-controller:latest
+IMG ?=  ray-operator:0.1.0
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/msft-operator/ray-operator/Makefile
+++ b/msft-operator/ray-operator/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?=  ray-operator:0.1.0
+IMG ?=  ray-controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/msft-operator/ray-operator/config/manager/manager.yaml
+++ b/msft-operator/ray-operator/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: bonsaidev.azurecr.io/bonsaidev/ray-operator:0.1.0
+        image: ray-controller:latest
         name: ray-manager
         resources:
           limits:

--- a/msft-operator/ray-operator/config/manager/manager.yaml
+++ b/msft-operator/ray-operator/config/manager/manager.yaml
@@ -27,13 +27,13 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: ray-controller:latest
+        image: bonsaidev.azurecr.io/bonsaidev/ray-operator:0.1.0
         name: ray-manager
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10

--- a/msft-operator/ray-operator/config/quota/priority.yaml
+++ b/msft-operator/ray-operator/config/quota/priority.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: ray-priority
+value: 100
+preemptionPolicy: Never
+globalDefault: false
+description: "This priority class is used for Ray pods."

--- a/msft-operator/ray-operator/config/quota/quota.yaml
+++ b/msft-operator/ray-operator/config/quota/quota.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: ray-quota
+spec:
+  hard:
+    cpu: "4000"
+    memory: 20Gi
+    pods: "5"
+  scopeSelector:
+    matchExpressions:
+    - operator : In
+      scopeName: PriorityClass
+      values: ["ray-priority"]

--- a/msft-operator/ray-operator/config/rbac/role_binding.yaml
+++ b/msft-operator/ray-operator/config/rbac/role_binding.yaml
@@ -10,3 +10,6 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: system
+- kind: ServiceAccount
+  name: default
+  namespace: default

--- a/msft-operator/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/msft-operator/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -55,7 +55,7 @@ spec:
           image: rayproject/autoscaler
           # you can have any command and args here to run your code. 
           # the below command/args will be appended after the Ray start command and it args, and executed after Ray start.
-          command: ["python"]
+          command: ["python3"]
           args:
           - '/opt/code.py'
           env:
@@ -91,11 +91,11 @@ spec:
                 command: ["/bin/sh","-c","ray stop"]
           resources:
             limits:
-              cpu: "2"
-              memory: "2G"
-            requests:
-              cpu: "1.5"
+              cpu: "1"
               memory: "1G"
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
           volumeMounts:
           - mountPath: /opt
             name: config
@@ -111,7 +111,7 @@ spec:
               path: code.py
   workerGroupsSpec:
   # the pod replicas in this group typed worker
-  - replicas: 2
+  - replicas: 1
     minReplicas: 1
     maxReplicas: 10
     # logical group name, for this called small-group, also can be functional
@@ -122,8 +122,9 @@ spec:
     # when a pod is confirmed to be deleted, its name will be removed from the list below
     #scaleStrategy:
     #  workersToDelete:
-    #  - worker-9m1rp
-    #  - worker-4k2ih 
+    #  - raycluster-complete-worker-small-group-bdtwh
+    #  - raycluster-complete-worker-small-group-hv457
+    #  - raycluster-complete-worker-small-group-k8tj7 
     # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
     rayStartParams:
       redis-password: 'LetMeInRay'
@@ -195,7 +196,7 @@ spec:
               name: log-volume
           resources:
             limits:
-              cpu: "2"
+              cpu: "1"
               memory: "512Mi"
             requests:
               cpu: "500m"

--- a/msft-operator/ray-operator/config/samples/ray-cluster.mini.yaml
+++ b/msft-operator/ray-operator/config/samples/ray-cluster.mini.yaml
@@ -32,8 +32,10 @@ spec:
       port: '6379' # should match headService targetPort
       object-manager-port: '12345'
       node-manager-port: '12346'
+      #include_webui: 'true'
       object-store-memory: '100000000'
       redis-password: 'LetMeInRay'
+      # webui_host: "10.1.2.60"
       dashboard-host: '0.0.0.0'
       num-cpus: '1' # can be auto-completed from the limits
       node-ip-address: $MY_POD_IP # auto-completed as the head pod IP
@@ -53,11 +55,13 @@ spec:
         containers:
         - name: ray-head
           image: rayproject/autoscaler
+          #image: rayproject/ray:nightly
+          #image: bonsaidev.azurecr.io/bonsai/lazer-0-9-0-cpu:dev
           # you can have any command and args here to run your code. 
           # the below command/args will be appended after the Ray start command and it args, and executed after Ray start.
-          command: ["python"]
+          command: ["sleep"]
           args:
-          - '/opt/code.py'
+          - '10000'
           env:
           - name: MY_POD_IP
             valueFrom:
@@ -65,17 +69,7 @@ spec:
                 fieldPath: status.podIP
           ports:
           - containerPort: 6379
-          volumeMounts:
-          - mountPath: /opt
-            name: config
-        volumes:
-        # You set volumes at the Pod level, then mount them into containers inside that Pod
-        - name: config
-          configMap:
-            # Provide the name of the ConfigMap you want to mount.
-            name: ray-code
-            # An array of keys from the ConfigMap to create as files
-            items:
-            - key: code.py
-              path: code.py
+          - containerPort: 8265 # Ray dashboard
+
+
 

--- a/msft-operator/ray-operator/controllers/common/service.go
+++ b/msft-operator/ray-operator/controllers/common/service.go
@@ -39,6 +39,13 @@ func BuildServiceForHeadPod(instance rayiov1alpha1.RayCluster) *corev1.Service {
 	instance.Spec.HeadService.Spec.ClusterIP = corev1.ClusterIPNone //headless service
 	rayPodSvc := &instance.Spec.HeadService
 	rayPodSvc.Name = checkSvcName(instance)
+
+	// set labels
+	if rayPodSvc.ObjectMeta.Labels == nil {
+		rayPodSvc.ObjectMeta.Labels = make(map[string]string)
+	}
+	rayPodSvc.ObjectMeta.Labels["isRayService"] = "yes"
+
 	return rayPodSvc
 }
 

--- a/msft-operator/ray-operator/controllers/utils/util.go
+++ b/msft-operator/ray-operator/controllers/utils/util.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"fmt"
+	"math"
 	"strconv"
 	"strings"
+	"unicode"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +16,65 @@ func IsCreated(pod *corev1.Pod) bool {
 	return pod.Status.Phase != ""
 }
 
-// Get substring before a string.
+// CheckName makes sure the name does not start with a numeric value and the total length is < 63 char
+func CheckName(s string) string {
+	maxLenght := 50 // 63 - (max(8,6) + 5 ) // 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.
+
+	if len(s) > maxLenght {
+		//shorten the name
+		offset := int(math.Abs(float64(maxLenght) - float64(len(s))))
+		fmt.Printf("pod name is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
+		s = s[offset:]
+	}
+
+	// cannot start with a numeric value
+	if unicode.IsDigit(rune(s[0])) {
+		s = "r" + s[1:]
+	}
+
+	// cannot start with a punctuation
+	if unicode.IsPunct(rune(s[0])) {
+		fmt.Println(s)
+		s = "r" + s[1:]
+	}
+
+	return s
+}
+
+// CheckLabel makes sure the label value does not start with a punctuation and the total length is < 63 char
+func CheckLabel(s string) string {
+	maxLenght := 63
+
+	if len(s) > maxLenght {
+		//shorten the name
+		offset := int(math.Abs(float64(maxLenght) - float64(len(s))))
+		fmt.Printf("label value is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
+		s = s[offset:]
+	}
+
+	// cannot start with a punctuation
+	if unicode.IsPunct(rune(s[0])) {
+		fmt.Println(s)
+		s = "r" + s[1:]
+	}
+
+	return s
+}
+
+// SetHeadSelector makes sure the selector is correct
+func SetHeadSelector(rayPodSvc *corev1.Service, rayClusterName string) {
+	if rayPodSvc.Spec.Selector == nil {
+		rayPodSvc.Spec.Selector = make(map[string]string)
+	}
+	if _, ok := rayPodSvc.Spec.Selector["identifier"]; !ok {
+		rayPodSvc.Spec.Selector["identifier"] = CheckLabel(fmt.Sprintf("%s-%s", rayClusterName, "head"))
+	}
+	if rayPodSvc.Spec.Selector["identifier"] != CheckLabel(fmt.Sprintf("%s-%s", rayClusterName, "head")) {
+		rayPodSvc.Spec.Selector["identifier"] = CheckLabel(fmt.Sprintf("%s-%s", rayClusterName, "head"))
+	}
+}
+
+// Before Get substring before a string.
 func Before(value string, a string) string {
 	pos := strings.Index(value, a)
 	if pos == -1 {

--- a/msft-operator/ray-operator/controllers/utils/util_test.go
+++ b/msft-operator/ray-operator/controllers/utils/util_test.go
@@ -32,6 +32,29 @@ func TestStatus(t *testing.T) {
 
 }
 
+func TestCheckName(t *testing.T) {
+
+	// test 1 -> change
+	str := "72fbcc7e-a661-4b18e-ca41-e903-fc3ae634b18e-lazer090scholar-director-s"
+	str = CheckName(str)
+	if str != "rca41-e903-fc3ae634b18e-lazer090scholar-director-s" {
+		t.Fail()
+	}
+	// test 2 -> change
+	str = "--------566666--------444433-----------222222----------4444"
+	str = CheckName(str)
+	if str != "r6666--------444433-----------222222----------4444" {
+		t.Fail()
+	}
+
+	// test 3 -> keep
+	str = "acceptable-name-head-12345"
+	str = CheckName(str)
+	if str != "acceptable-name-head-12345" {
+		t.Fail()
+	}
+}
+
 func createSomePod() (pod *corev1.Pod) {
 
 	return &corev1.Pod{

--- a/msft-operator/ray-operator/go.sum
+++ b/msft-operator/ray-operator/go.sum
@@ -248,6 +248,7 @@ k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d h1:7Kns6qqhMAQWvGkxYOLSLR
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d/go.mod h1:3jediapYqJ2w1BFw7lAZPCx7scubsTfosqHkhXCWJKw=
 k8s.io/apimachinery v0.19.3 h1:bpIQXlKjB4cB/oNpnNnV+BybGPR7iP5oYpsOTEJ4hgc=
 k8s.io/apimachinery v0.19.4 h1:+ZoddM7nbzrDCp0T3SWnyxqf8cbWPT2fkZImoyvHUG0=
+k8s.io/apimachinery v0.20.1 h1:LAhz8pKbgR8tUwn7boK+b2HZdt7MiTu2mkYtFMUjTRQ=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a h1:huOvPq1vO7dkuw9rZPYsLGpFmyGvy6L8q6mDItgkdQ4=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a/go.mod h1:3YAcTbI2ArBRmhHns5vlHRX8YQqvkVYpz+U/N5i1mVU=


### PR DESCRIPTION
The deletion of workers has only been allowed through a scaleStrategy where the specific names of the pods to be removed has to be defined.

This PR keeps that logic, but adds the ability to remove random workers if the scaleStrategy does not define any specific pods.

E.g. if current running worker pods in a group is `5`
and you modify the `replicas = 3` with only 1 pod in the scaleStrategy, e.g.
```
scaleStrategy:
     workersToDelete:
     - raycluster-complete-worker-small-group-bdtwh
```
Then the second to be removed will be randomly selected by the ray operator