### PR TITLE
Fix leader election failure and crd too long issue

### DIFF
--- a/bytedance/CONTRIBUTING.md
+++ b/bytedance/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing Guidelines
+
+Read the following guide if you're interested in contributing to ray operator project.
+
+## Finding Things That Need Help
+
+If you're new to the project and want to help, but don't know where to start, we have a semi-curated list of issues that should not need deep knowledge of the system. Have a look and see if anything sounds interesting. If the issue has been assigned, reach out to the assignee. Alternatively, read some of the docs on other controllers and try to write your own, file and fix any/all issues that come up, including gaps in the documentation!
+
+## Contributing a Patch
+
+1. Clone the desired repo, develop and test your code changes.
+2. Submit a pull request.
+
+All changes must be code reviewed. We don't have clear coding conventions and standards now, try to `gofmt` your code before check in. 
+Expect reviewers to request that you avoid common [go style mistakes](https://github.com/golang/go/wiki/CodeReviewComments) in your PRs.
+
+## Features and bugs
+
+Feel free to open issues to report bugs or features.

--- a/bytedance/Makefile
+++ b/bytedance/Makefile
@@ -1,8 +1,8 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= bytedance/ray-operator:latest
+IMG ?= bytedance/ray-operator:v0.1.0
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd:maxDescLen=100,trivialVersions=true,preserveUnknownFields=false"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/bytedance/README.md
+++ b/bytedance/README.md
@@ -1,0 +1,32 @@
+# Ray Operator for Kubernetes
+
+> Note: this project is still experimental
+
+## Why was this operator created? 
+
+This decision to create a new operator wasn't made lightly, but it was necessary due to some drawbacks 
+that are present in upstream [ray-operator](https://docs.ray.io/en/releases-1.2.0/cluster/k8s-operator.html). 
+Current upstream operator mix operator and autoscaler in a single component, which 
+make us really hard to manage multiple versions of Ray cluster in multi-tenant environments. What's more, 
+quality and performance of python based operator is still hard to match commonly used golang operator framework. 
+
+Ideally, this operator will extract autoscaler as a separate component and create one for each cluster.
+It is responsible for make scaling decisions and tell operator how many pods to bring up or which pods to scale in. The good thing is we are not alone, 
+Anyscale, Ant Group and Microsoft kicked off this discussion on [designs](https://docs.google.com/document/d/1DPS-e34DkqQ4AeJpoBnSrUM8SnHnQVkiLlcmI4zWEWg/edit?ts=5f906e13#) in 2020.
+We will follow the path of the predecessors and make it better. 
+
+## Features
+
+- Support multiple ray version and rayclusters crd version in multi-tenant environments.
+- Flexible options to expose head service to fit different network environments. 
+- Support ray cluster rolling upgrade. (coming soon)
+- Expose rich telemetry of ray clusters. (coming soon)
+
+## Discussion, Contribution and Support
+
+If you have questions or what to get the latest project news, you can connect with us in the following ways:
+ 
+- Chat with team members (@Jiaxin Shan, @Mengyuan Chao) in Ray Slack Group
+- Create Github issues
+ 
+See also our [contributor guide](./CONTRIBUTING.md) for more details on how to get involved.

--- a/bytedance/cmd/main.go
+++ b/bytedance/cmd/main.go
@@ -71,7 +71,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "6adafd3f.",
+		LeaderElectionID:       "6adafd3f",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/bytedance/config/crd/bases/ray.io_rayclusters.yaml
+++ b/bytedance/config/crd/bases/ray.io_rayclusters.yaml
@@ -22,14 +22,12 @@ spec:
         description: RayCluster is the Schema for the rayclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
@@ -38,7 +36,7 @@ spec:
             properties:
               autoscalingEnabled:
                 description: AutoscalingEnabled indicates if we want to enable autoscaling
-                  for this cluster. By default it's disabled in v1alpha1
+                  for this cluster.
                 type: boolean
               headNodeSpec:
                 description: HeadNodeSpec is the spec for the head node
@@ -58,17 +56,16 @@ spec:
                       pod
                     properties:
                       metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        description: 'Standard object''s metadata. More info: https://git.k8s.'
                         type: object
                       spec:
                         description: 'Specification of the desired behavior of the
-                          pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          pod. More info: https://git.k8s.'
                         properties:
                           activeDeadlineSeconds:
                             description: Optional duration in seconds the pod may
                               be active on the node relative to StartTime before the
-                              system will actively try to mark it failed and kill
-                              associated containers. Value must be a positive integer.
+                              syst
                             format: int64
                             type: integer
                           affinity:
@@ -79,24 +76,13 @@ spec:
                                   for the pod.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule
+                                    description: 'The scheduler will prefer to schedule
                                       pods to nodes that satisfy the affinity expressions
-                                      specified by this field, but it may choose a
-                                      node that violates one or more of the expressions.
-                                      The node that is most preferred is the one with
-                                      the greatest sum of weights, i.e. for each node
-                                      that meets all of the scheduling requirements
-                                      (resource request, requiredDuringScheduling
-                                      affinity expressions, etc.), compute a sum by
-                                      iterating through the elements of this field
-                                      and adding "weight" to the sum if the node matches
-                                      the corresponding matchExpressions; the node(s)
-                                      with the highest sum are the most preferred.
+                                      specified '
                                     items:
                                       description: An empty preferred scheduling term
                                         matches all objects with implicit weight 0
-                                        (i.e. it's a no-op). A null preferred scheduling
-                                        term matches no objects (i.e. is also a no-op).
+                                        (i.e. it's a no-op).
                                       properties:
                                         preference:
                                           description: A node selector term, associated
@@ -106,10 +92,9 @@ spec:
                                               description: A list of node selector
                                                 requirements by node's labels.
                                               items:
-                                                description: A node selector requirement
+                                                description: 'A node selector requirement
                                                   is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                  a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that
@@ -118,23 +103,12 @@ spec:
                                                   operator:
                                                     description: Represents a key's
                                                       relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
                                                     type: string
                                                   values:
                                                     description: An array of string
                                                       values. If the operator is In
                                                       or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
+                                                      be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -147,10 +121,9 @@ spec:
                                               description: A list of node selector
                                                 requirements by node's fields.
                                               items:
-                                                description: A node selector requirement
+                                                description: 'A node selector requirement
                                                   is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                  a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that
@@ -159,23 +132,12 @@ spec:
                                                   operator:
                                                     description: Represents a key's
                                                       relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
                                                     type: string
                                                   values:
                                                     description: An array of string
                                                       values. If the operator is In
                                                       or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
+                                                      be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -199,12 +161,7 @@ spec:
                                   requiredDuringSchedulingIgnoredDuringExecution:
                                     description: If the affinity requirements specified
                                       by this field are not met at scheduling time,
-                                      the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this
-                                      field cease to be met at some point during pod
-                                      execution (e.g. due to an update), the system
-                                      may or may not try to eventually evict the pod
-                                      from its node.
+                                      the pod will no
                                     properties:
                                       nodeSelectorTerms:
                                         description: Required. A list of node selector
@@ -212,17 +169,15 @@ spec:
                                         items:
                                           description: A null or empty node selector
                                             term matches no objects. The requirements
-                                            of them are ANDed. The TopologySelectorTerm
-                                            type implements a subset of the NodeSelectorTerm.
+                                            of them are ANDed.
                                           properties:
                                             matchExpressions:
                                               description: A list of node selector
                                                 requirements by node's labels.
                                               items:
-                                                description: A node selector requirement
+                                                description: 'A node selector requirement
                                                   is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                  a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that
@@ -231,23 +186,12 @@ spec:
                                                   operator:
                                                     description: Represents a key's
                                                       relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
                                                     type: string
                                                   values:
                                                     description: An array of string
                                                       values. If the operator is In
                                                       or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
+                                                      be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -260,10 +204,9 @@ spec:
                                               description: A list of node selector
                                                 requirements by node's fields.
                                               items:
-                                                description: A node selector requirement
+                                                description: 'A node selector requirement
                                                   is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                  a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that
@@ -272,23 +215,12 @@ spec:
                                                   operator:
                                                     description: Represents a key's
                                                       relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
                                                     type: string
                                                   values:
                                                     description: An array of string
                                                       values. If the operator is In
                                                       or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
+                                                      be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -306,27 +238,16 @@ spec:
                               podAffinity:
                                 description: Describes pod affinity scheduling rules
                                   (e.g. co-locate this pod in the same node, zone,
-                                  etc. as some other pod(s)).
+                                  etc.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule
+                                    description: 'The scheduler will prefer to schedule
                                       pods to nodes that satisfy the affinity expressions
-                                      specified by this field, but it may choose a
-                                      node that violates one or more of the expressions.
-                                      The node that is most preferred is the one with
-                                      the greatest sum of weights, i.e. for each node
-                                      that meets all of the scheduling requirements
-                                      (resource request, requiredDuringScheduling
-                                      affinity expressions, etc.), compute a sum by
-                                      iterating through the elements of this field
-                                      and adding "weight" to the sum if the node has
-                                      pods which matches the corresponding podAffinityTerm;
-                                      the node(s) with the highest sum are the most
-                                      preferred.
+                                      specified '
                                     items:
                                       description: The weights of all of the matched
                                         WeightedPodAffinityTerm fields are added per-node
-                                        to find the most preferred node(s)
+                                        to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term,
@@ -344,8 +265,7 @@ spec:
                                                     description: A label selector
                                                       requirement is a selector that
                                                       contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                      an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -355,21 +275,11 @@ spec:
                                                       operator:
                                                         description: operator represents
                                                           a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                          a set of values.
                                                         type: string
                                                       values:
                                                         description: values is an
                                                           array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -382,35 +292,20 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                             namespaces:
-                                              description: namespaces specifies which
+                                              description: 'namespaces specifies which
                                                 namespaces the labelSelector applies
-                                                to (matches against); null or empty
-                                                list means "this pod's namespace"
+                                                to (matches against); null or empty '
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
                                               description: This pod should be co-located
                                                 (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                                with the pods matching th
                                               type: string
                                           required:
                                           - topologyKey
@@ -429,24 +324,11 @@ spec:
                                   requiredDuringSchedulingIgnoredDuringExecution:
                                     description: If the affinity requirements specified
                                       by this field are not met at scheduling time,
-                                      the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this
-                                      field cease to be met at some point during pod
-                                      execution (e.g. due to a pod label update),
-                                      the system may or may not try to eventually
-                                      evict the pod from its node. When there are
-                                      multiple elements, the lists of nodes corresponding
-                                      to each podAffinityTerm are intersected, i.e.
-                                      all terms must be satisfied.
+                                      the pod will no
                                     items:
                                       description: Defines a set of pods (namely those
                                         matching the labelSelector relative to the
-                                        given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity)
-                                        with, where co-located is defined as running
-                                        on a node whose value of the label with key
-                                        <topologyKey> matches that of any node on
-                                        which a pod of the set of pods is running
+                                        given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of
@@ -460,7 +342,6 @@ spec:
                                                 description: A label selector requirement
                                                   is a selector that contains values,
                                                   a key, and an operator that relates
-                                                  the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -470,18 +351,11 @@ spec:
                                                   operator:
                                                     description: operator represents
                                                       a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                      of values.
                                                     type: string
                                                   values:
                                                     description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                      of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -494,33 +368,20 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies which
+                                          description: 'namespaces specifies which
                                             namespaces the labelSelector applies to
-                                            (matches against); null or empty list
-                                            means "this pod's namespace"
+                                            (matches against); null or empty '
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
                                           description: This pod should be co-located
                                             (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                            with the pods matching th
                                           type: string
                                       required:
                                       - topologyKey
@@ -529,28 +390,16 @@ spec:
                                 type: object
                               podAntiAffinity:
                                 description: Describes pod anti-affinity scheduling
-                                  rules (e.g. avoid putting this pod in the same node,
-                                  zone, etc. as some other pod(s)).
+                                  rules (e.g.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
                                     description: The scheduler will prefer to schedule
                                       pods to nodes that satisfy the anti-affinity
-                                      expressions specified by this field, but it
-                                      may choose a node that violates one or more
-                                      of the expressions. The node that is most preferred
-                                      is the one with the greatest sum of weights,
-                                      i.e. for each node that meets all of the scheduling
-                                      requirements (resource request, requiredDuringScheduling
-                                      anti-affinity expressions, etc.), compute a
-                                      sum by iterating through the elements of this
-                                      field and adding "weight" to the sum if the
-                                      node has pods which matches the corresponding
-                                      podAffinityTerm; the node(s) with the highest
-                                      sum are the most preferred.
+                                      expressions speci
                                     items:
                                       description: The weights of all of the matched
                                         WeightedPodAffinityTerm fields are added per-node
-                                        to find the most preferred node(s)
+                                        to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term,
@@ -568,8 +417,7 @@ spec:
                                                     description: A label selector
                                                       requirement is a selector that
                                                       contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                      an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -579,21 +427,11 @@ spec:
                                                       operator:
                                                         description: operator represents
                                                           a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                          a set of values.
                                                         type: string
                                                       values:
                                                         description: values is an
                                                           array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -606,35 +444,20 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                             namespaces:
-                                              description: namespaces specifies which
+                                              description: 'namespaces specifies which
                                                 namespaces the labelSelector applies
-                                                to (matches against); null or empty
-                                                list means "this pod's namespace"
+                                                to (matches against); null or empty '
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
                                               description: This pod should be co-located
                                                 (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                                with the pods matching th
                                               type: string
                                           required:
                                           - topologyKey
@@ -653,24 +476,11 @@ spec:
                                   requiredDuringSchedulingIgnoredDuringExecution:
                                     description: If the anti-affinity requirements
                                       specified by this field are not met at scheduling
-                                      time, the pod will not be scheduled onto the
-                                      node. If the anti-affinity requirements specified
-                                      by this field cease to be met at some point
-                                      during pod execution (e.g. due to a pod label
-                                      update), the system may or may not try to eventually
-                                      evict the pod from its node. When there are
-                                      multiple elements, the lists of nodes corresponding
-                                      to each podAffinityTerm are intersected, i.e.
-                                      all terms must be satisfied.
+                                      time, the pod wi
                                     items:
                                       description: Defines a set of pods (namely those
                                         matching the labelSelector relative to the
-                                        given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity)
-                                        with, where co-located is defined as running
-                                        on a node whose value of the label with key
-                                        <topologyKey> matches that of any node on
-                                        which a pod of the set of pods is running
+                                        given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of
@@ -684,7 +494,6 @@ spec:
                                                 description: A label selector requirement
                                                   is a selector that contains values,
                                                   a key, and an operator that relates
-                                                  the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -694,18 +503,11 @@ spec:
                                                   operator:
                                                     description: operator represents
                                                       a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                      of values.
                                                     type: string
                                                   values:
                                                     description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                      of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -718,33 +520,20 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies which
+                                          description: 'namespaces specifies which
                                             namespaces the labelSelector applies to
-                                            (matches against); null or empty list
-                                            means "this pod's namespace"
+                                            (matches against); null or empty '
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
                                           description: This pod should be co-located
                                             (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                            with the pods matching th
                                           type: string
                                       required:
                                       - topologyKey
@@ -754,41 +543,24 @@ spec:
                             type: object
                           automountServiceAccountToken:
                             description: AutomountServiceAccountToken indicates whether
-                              a service account token should be automatically mounted.
+                              a service account token should be automatically mount
                             type: boolean
                           containers:
                             description: List of containers belonging to the pod.
-                              Containers cannot currently be added or removed. There
-                              must be at least one container in a Pod. Cannot be updated.
+                              Containers cannot currently be added or removed.
                             items:
                               description: A single application container that you
                                 want to run within a pod.
                               properties:
                                 args:
-                                  description: 'Arguments to the entrypoint. The docker
-                                    image''s CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using
-                                    the container''s environment. If a variable cannot
-                                    be resolved, the reference in the input string
-                                    will be unchanged. The $(VAR_NAME) syntax can
-                                    be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: Arguments to the entrypoint. The docker
+                                    image's CMD is used if this is not provided.
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: 'Entrypoint array. Not executed within
-                                    a shell. The docker image''s ENTRYPOINT is used
-                                    if this is not provided. Variable references $(VAR_NAME)
-                                    are expanded using the container''s environment.
-                                    If a variable cannot be resolved, the reference
-                                    in the input string will be unchanged. The $(VAR_NAME)
-                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: Entrypoint array. Not executed within
+                                    a shell.
                                   items:
                                     type: string
                                   type: array
@@ -804,17 +576,9 @@ spec:
                                           Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: 'Variable references $(VAR_NAME)
+                                        description: Variable references $(VAR_NAME)
                                           are expanded using the previous defined
-                                          environment variables in the container and
-                                          any service environment variables. If a
-                                          variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Defaults to
-                                          "".'
+                                          environment variables in the
                                         type: string
                                       valueFrom:
                                         description: Source for the environment variable's
@@ -828,9 +592,7 @@ spec:
                                                 type: string
                                               name:
                                                 description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -842,9 +604,7 @@ spec:
                                           fieldRef:
                                             description: 'Selects a field of the pod:
                                               supports metadata.name, metadata.namespace,
-                                              `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                              spec.nodeName, spec.serviceAccountName,
-                                              status.hostIP, status.podIP, status.podIPs.'
+                                              `metadata.'
                                             properties:
                                               apiVersion:
                                                 description: Version of the schema
@@ -861,10 +621,7 @@ spec:
                                           resourceFieldRef:
                                             description: 'Selects a resource of the
                                               container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              limits.ephemeral-storage, requests.cpu,
-                                              requests.memory and requests.ephemeral-storage)
-                                              are currently supported.'
+                                              requests (limits.cpu, limits.'
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -897,9 +654,7 @@ spec:
                                                 type: string
                                               name:
                                                 description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -915,14 +670,7 @@ spec:
                                   type: array
                                 envFrom:
                                   description: List of sources to populate environment
-                                    variables in the container. The keys defined within
-                                    a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container
-                                    is starting. When a key exists in multiple sources,
-                                    the value associated with the last source will
-                                    take precedence. Values defined by an Env with
-                                    a duplicate key will take precedence. Cannot be
-                                    updated.
+                                    variables in the container.
                                   items:
                                     description: EnvFromSource represents the source
                                       of a set of ConfigMaps
@@ -932,9 +680,7 @@ spec:
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -951,9 +697,7 @@ spec:
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -963,29 +707,20 @@ spec:
                                     type: object
                                   type: array
                                 image:
-                                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config
-                                    management to default or override container images
-                                    in workload controllers like Deployments and StatefulSets.'
+                                  description: 'Docker image name. More info: https://kubernetes.'
                                   type: string
                                 imagePullPolicy:
-                                  description: 'Image pull policy. One of Always,
-                                    Never, IfNotPresent. Defaults to Always if :latest
-                                    tag is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                  description: Image pull policy. One of Always, Never,
+                                    IfNotPresent.
                                   type: string
                                 lifecycle:
                                   description: Actions that the management system
                                     should take in response to container lifecycle
-                                    events. Cannot be updated.
+                                    events.
                                   properties:
                                     postStart:
-                                      description: 'PostStart is called immediately
-                                        after a container is created. If the handler
-                                        fails, the container is terminated and restarted
-                                        according to its restart policy. Other management
-                                        of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: PostStart is called immediately
+                                        after a container is created.
                                       properties:
                                         exec:
                                           description: One and only one of the following
@@ -993,17 +728,9 @@ spec:
                                             action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
+                                              description: 'Command is the command
                                                 line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
@@ -1014,9 +741,7 @@ spec:
                                           properties:
                                             host:
                                               description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -1050,8 +775,7 @@ spec:
                                               - type: string
                                               description: Name or number of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
@@ -1061,10 +785,8 @@ spec:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -1076,29 +798,16 @@ spec:
                                               - type: string
                                               description: Number or name of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: 'PreStop is called immediately
-                                        before a container is terminated due to an
-                                        API request or management event such as liveness/startup
-                                        probe failure, preemption, resource contention,
-                                        etc. The handler is not called if the container
-                                        crashes or exits. The reason for termination
-                                        is passed to the handler. The Pod''s termination
-                                        grace period countdown begins before the PreStop
-                                        hooked is executed. Regardless of the outcome
-                                        of the handler, the container will eventually
-                                        terminate within the Pod''s termination grace
-                                        period. Other management of the container
-                                        blocks until the hook completes or until the
-                                        termination grace period is reached. More
-                                        info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: PreStop is called immediately before
+                                        a container is terminated due to an API request
+                                        or management e
                                       properties:
                                         exec:
                                           description: One and only one of the following
@@ -1106,17 +815,9 @@ spec:
                                             action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
+                                              description: 'Command is the command
                                                 line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
@@ -1127,9 +828,7 @@ spec:
                                           properties:
                                             host:
                                               description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -1163,8 +862,7 @@ spec:
                                               - type: string
                                               description: Name or number of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
@@ -1174,10 +872,8 @@ spec:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -1189,8 +885,7 @@ spec:
                                               - type: string
                                               description: Number or name of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -1198,9 +893,8 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: 'Periodic probe of container liveness.
+                                  description: Periodic probe of container liveness.
                                     Container will be restarted if the probe fails.
-                                    Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   properties:
                                     exec:
                                       description: One and only one of the following
@@ -1208,16 +902,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -1225,8 +912,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -1235,8 +921,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -1266,8 +951,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -1277,9 +961,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -1291,15 +974,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1311,33 +991,24 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
                                   description: Name of the container specified as
-                                    a DNS_LABEL. Each container in a pod must have
-                                    a unique name (DNS_LABEL). Cannot be updated.
+                                    a DNS_LABEL.
                                   type: string
                                 ports:
                                   description: List of ports to expose from the container.
-                                    Exposing a port here gives the system additional
-                                    information about the network connections a container
-                                    uses, but is primarily informational. Not specifying
-                                    a port here DOES NOT prevent that port from being
-                                    exposed. Any port which is listening on the default
-                                    "0.0.0.0" address inside a container will be accessible
-                                    from the network. Cannot be updated.
                                   items:
                                     description: ContainerPort represents a network
                                       port in a single container.
@@ -1355,17 +1026,12 @@ spec:
                                       hostPort:
                                         description: Number of port to expose on the
                                           host. If specified, this must be a valid
-                                          port number, 0 < x < 65536. If HostNetwork
-                                          is specified, this must match ContainerPort.
-                                          Most containers do not need this.
+                                          port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       name:
                                         description: If specified, this must be an
                                           IANA_SVC_NAME and unique within the pod.
-                                          Each named port in a pod must have a unique
-                                          name. Name for the port that can be referred
-                                          to by services.
                                         type: string
                                       protocol:
                                         default: TCP
@@ -1381,10 +1047,8 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: 'Periodic probe of container service
-                                    readiness. Container will be removed from service
-                                    endpoints if the probe fails. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: Periodic probe of container service
+                                    readiness.
                                   properties:
                                     exec:
                                       description: One and only one of the following
@@ -1392,16 +1056,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -1409,8 +1066,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -1419,8 +1075,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -1450,8 +1105,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -1461,9 +1115,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -1475,15 +1128,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1495,22 +1145,21 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 resources:
                                   description: 'Compute Resources required by this
-                                    container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    container. Cannot be updated. More info: https://kubernetes.'
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -1520,7 +1169,7 @@ spec:
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        of compute resources allowed. More info: https://kubernetes.'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -1529,33 +1178,22 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 securityContext:
                                   description: 'Security options the pod should run
-                                    with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    with. More info: https://kubernetes.'
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: 'AllowPrivilegeEscalation controls
+                                      description: AllowPrivilegeEscalation controls
                                         whether a process can gain more privileges
-                                        than its parent process. This bool directly
-                                        controls if the no_new_privs flag will be
-                                        set on the container process. AllowPrivilegeEscalation
-                                        is true always when the container is: 1) run
-                                        as Privileged 2) has CAP_SYS_ADMIN'
+                                        than its parent process
                                       type: boolean
                                     capabilities:
                                       description: The capabilities to add/drop when
-                                        running containers. Defaults to the default
-                                        set of capabilities granted by the container
-                                        runtime.
+                                        running containers.
                                       properties:
                                         add:
                                           description: Added capabilities
@@ -1574,17 +1212,10 @@ spec:
                                       type: object
                                     privileged:
                                       description: Run container in privileged mode.
-                                        Processes in privileged containers are essentially
-                                        equivalent to root on the host. Defaults to
-                                        false.
                                       type: boolean
                                     procMount:
                                       description: procMount denotes the type of proc
-                                        mount to use for the containers. The default
-                                        is DefaultProcMount which uses the container
-                                        runtime defaults for readonly paths and masked
-                                        paths. This requires the ProcMountType feature
-                                        flag to be enabled.
+                                        mount to use for the containers.
                                       type: string
                                     readOnlyRootFilesystem:
                                       description: Whether this container has a read-only
@@ -1593,41 +1224,21 @@ spec:
                                     runAsGroup:
                                       description: The GID to run the entrypoint of
                                         the container process. Uses runtime default
-                                        if unset. May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        if unset.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
                                       description: Indicates that the container must
-                                        run as a non-root user. If true, the Kubelet
-                                        will validate the image at runtime to ensure
-                                        that it does not run as UID 0 (root) and fail
-                                        to start the container if it does. If unset
-                                        or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        run as a non-root user.
                                       type: boolean
                                     runAsUser:
                                       description: The UID to run the entrypoint of
-                                        the container process. Defaults to user specified
-                                        in image metadata if unspecified. May also
-                                        be set in PodSecurityContext.  If set in both
-                                        SecurityContext and PodSecurityContext, the
-                                        value specified in SecurityContext takes precedence.
+                                        the container process.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
                                       description: The SELinux context to be applied
-                                        to the container. If unspecified, the container
-                                        runtime will allocate a random SELinux context
-                                        for each container.  May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        to the container.
                                       properties:
                                         level:
                                           description: Level is SELinux level label
@@ -1648,45 +1259,27 @@ spec:
                                       type: object
                                     seccompProfile:
                                       description: The seccomp options to use by this
-                                        container. If seccomp options are provided
-                                        at both the pod & container level, the container
-                                        options override the pod options.
+                                        container.
                                       properties:
                                         localhostProfile:
                                           description: localhostProfile indicates
                                             a profile defined in a file on the node
-                                            should be used. The profile must be preconfigured
-                                            on the node to work. Must be a descending
-                                            path, relative to the kubelet's configured
-                                            seccomp profile location. Must only be
-                                            set if type is "Localhost".
+                                            should be used.
                                           type: string
                                         type:
-                                          description: "type indicates which kind
-                                            of seccomp profile will be applied. Valid
-                                            options are: \n Localhost - a profile
-                                            defined in a file on the node should be
-                                            used. RuntimeDefault - the container runtime
-                                            default profile should be used. Unconfined
-                                            - no profile should be applied."
+                                          description: type indicates which kind of
+                                            seccomp profile will be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
                                       description: The Windows specific settings applied
-                                        to all containers. If unspecified, the options
-                                        from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        to all containers.
                                       properties:
                                         gmsaCredentialSpec:
                                           description: GMSACredentialSpec is where
-                                            the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                            inlines the contents of the GMSA credential
-                                            spec named by the GMSACredentialSpecName
-                                            field.
+                                            the GMSA admission webhook (https://github.
                                           type: string
                                         gmsaCredentialSpecName:
                                           description: GMSACredentialSpecName is the
@@ -1695,27 +1288,12 @@ spec:
                                         runAsUserName:
                                           description: The UserName in Windows to
                                             run the entrypoint of the container process.
-                                            Defaults to the user specified in image
-                                            metadata if unspecified. May also be set
-                                            in PodSecurityContext. If set in both
-                                            SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: 'StartupProbe indicates that the Pod
-                                    has successfully initialized. If specified, no
-                                    other probes are executed until this completes
-                                    successfully. If this probe fails, the Pod will
-                                    be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters
-                                    at the beginning of a Pod''s lifecycle, when it
-                                    might take a long time to load data or warm a
-                                    cache, than during steady-state operation. This
-                                    cannot be updated. This is a beta feature enabled
-                                    by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: StartupProbe indicates that the Pod
+                                    has successfully initialized.
                                   properties:
                                     exec:
                                       description: One and only one of the following
@@ -1723,16 +1301,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -1740,8 +1311,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -1750,8 +1320,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -1781,8 +1350,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -1792,9 +1360,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -1806,15 +1373,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1826,65 +1390,40 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
                                   description: Whether this container should allocate
-                                    a buffer for stdin in the container runtime. If
-                                    this is not set, reads from stdin in the container
-                                    will always result in EOF. Default is false.
+                                    a buffer for stdin in the container runtime.
                                   type: boolean
                                 stdinOnce:
                                   description: Whether the container runtime should
                                     close the stdin channel after it has been opened
-                                    by a single attach. When stdin is true the stdin
-                                    stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is
-                                    opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains
-                                    open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed
-                                    until the container is restarted. If this flag
-                                    is false, a container processes that reads from
-                                    stdin will never receive an EOF. Default is false
+                                    by a single at
                                   type: boolean
                                 terminationMessagePath:
                                   description: 'Optional: Path at which the file to
                                     which the container''s termination message will
-                                    be written is mounted into the container''s filesystem.
-                                    Message written is intended to be brief final
-                                    status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than
-                                    4096 bytes. The total message length across all
-                                    containers will be limited to 12kb. Defaults to
-                                    /dev/termination-log. Cannot be updated.'
+                                    be written is mou'
                                   type: string
                                 terminationMessagePolicy:
                                   description: Indicate how the termination message
-                                    should be populated. File will use the contents
-                                    of terminationMessagePath to populate the container
-                                    status message on both success and failure. FallbackToLogsOnError
-                                    will use the last chunk of container log output
-                                    if the termination message file is empty and the
-                                    container exited with an error. The log output
-                                    is limited to 2048 bytes or 80 lines, whichever
-                                    is smaller. Defaults to File. Cannot be updated.
+                                    should be populated.
                                   type: string
                                 tty:
                                   description: Whether this container should allocate
                                     a TTY for itself, also requires 'stdin' to be
-                                    true. Default is false.
+                                    true.
                                   type: boolean
                                 volumeDevices:
                                   description: volumeDevices is the list of block
@@ -1922,9 +1461,7 @@ spec:
                                       mountPropagation:
                                         description: mountPropagation determines how
                                           mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
+                                          and the other way a
                                         type: string
                                       name:
                                         description: This must match the Name of a
@@ -1938,16 +1475,11 @@ spec:
                                       subPath:
                                         description: Path within the volume from which
                                           the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
                                         description: Expanded path within the volume
                                           from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
+                                          be mounted.
                                         type: string
                                     required:
                                     - mountPath
@@ -1955,33 +1487,24 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: Container's working directory. If not
-                                    specified, the container runtime's default will
-                                    be used, which might be configured in the container
-                                    image. Cannot be updated.
+                                  description: Container's working directory.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           dnsConfig:
-                            description: Specifies the DNS parameters of a pod. Parameters
-                              specified here will be merged to the generated DNS configuration
-                              based on DNSPolicy.
+                            description: Specifies the DNS parameters of a pod.
                             properties:
                               nameservers:
                                 description: A list of DNS name server IP addresses.
-                                  This will be appended to the base nameservers generated
-                                  from DNSPolicy. Duplicated nameservers will be removed.
                                 items:
                                   type: string
                                 type: array
                               options:
                                 description: A list of DNS resolver options. This
                                   will be merged with the base options generated from
-                                  DNSPolicy. Duplicated entries will be removed. Resolution
-                                  options given in Options will override those that
-                                  appear in the base DNSPolicy.
+                                  DNSPolicy.
                                 items:
                                   description: PodDNSConfigOption defines DNS resolver
                                     options of a pod.
@@ -1995,77 +1518,34 @@ spec:
                                 type: array
                               searches:
                                 description: A list of DNS search domains for host-name
-                                  lookup. This will be appended to the base search
-                                  paths generated from DNSPolicy. Duplicated search
-                                  paths will be removed.
+                                  lookup.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           dnsPolicy:
                             description: Set DNS policy for the pod. Defaults to "ClusterFirst".
-                              Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
-                              'Default' or 'None'. DNS parameters given in DNSConfig
-                              will be merged with the policy selected with DNSPolicy.
-                              To have DNS options set along with hostNetwork, you
-                              have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                             type: string
                           enableServiceLinks:
-                            description: 'EnableServiceLinks indicates whether information
-                              about services should be injected into pod''s environment
-                              variables, matching the syntax of Docker links. Optional:
-                              Defaults to true.'
+                            description: EnableServiceLinks indicates whether information
+                              about services should be injected into pod's enviro
                             type: boolean
                           ephemeralContainers:
                             description: List of ephemeral containers run in this
-                              pod. Ephemeral containers may be run in an existing
-                              pod to perform user-initiated actions such as debugging.
-                              This list cannot be specified when creating a pod, and
-                              it cannot be modified by updating the pod spec. In order
-                              to add an ephemeral container to an existing pod, use
-                              the pod's ephemeralcontainers subresource. This field
-                              is alpha-level and is only honored by servers that enable
-                              the EphemeralContainers feature.
+                              pod.
                             items:
                               description: An EphemeralContainer is a container that
-                                may be added temporarily to an existing pod for user-initiated
-                                activities such as debugging. Ephemeral containers
-                                have no resource or scheduling guarantees, and they
-                                will not be restarted when they exit or when a pod
-                                is removed or restarted. If an ephemeral container
-                                causes a pod to exceed its resource allocation, the
-                                pod may be evicted. Ephemeral containers may not be
-                                added by directly updating the pod spec. They must
-                                be added via the pod's ephemeralcontainers subresource,
-                                and they will appear in the pod spec once added. This
-                                is an alpha feature enabled by the EphemeralContainers
-                                feature flag.
+                                may be added temporarily to an existing pod for user-initi
                               properties:
                                 args:
-                                  description: 'Arguments to the entrypoint. The docker
-                                    image''s CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using
-                                    the container''s environment. If a variable cannot
-                                    be resolved, the reference in the input string
-                                    will be unchanged. The $(VAR_NAME) syntax can
-                                    be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: Arguments to the entrypoint. The docker
+                                    image's CMD is used if this is not provided.
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: 'Entrypoint array. Not executed within
-                                    a shell. The docker image''s ENTRYPOINT is used
-                                    if this is not provided. Variable references $(VAR_NAME)
-                                    are expanded using the container''s environment.
-                                    If a variable cannot be resolved, the reference
-                                    in the input string will be unchanged. The $(VAR_NAME)
-                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: Entrypoint array. Not executed within
+                                    a shell.
                                   items:
                                     type: string
                                   type: array
@@ -2081,17 +1561,9 @@ spec:
                                           Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: 'Variable references $(VAR_NAME)
+                                        description: Variable references $(VAR_NAME)
                                           are expanded using the previous defined
-                                          environment variables in the container and
-                                          any service environment variables. If a
-                                          variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Defaults to
-                                          "".'
+                                          environment variables in the
                                         type: string
                                       valueFrom:
                                         description: Source for the environment variable's
@@ -2105,9 +1577,7 @@ spec:
                                                 type: string
                                               name:
                                                 description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -2119,9 +1589,7 @@ spec:
                                           fieldRef:
                                             description: 'Selects a field of the pod:
                                               supports metadata.name, metadata.namespace,
-                                              `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                              spec.nodeName, spec.serviceAccountName,
-                                              status.hostIP, status.podIP, status.podIPs.'
+                                              `metadata.'
                                             properties:
                                               apiVersion:
                                                 description: Version of the schema
@@ -2138,10 +1606,7 @@ spec:
                                           resourceFieldRef:
                                             description: 'Selects a resource of the
                                               container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              limits.ephemeral-storage, requests.cpu,
-                                              requests.memory and requests.ephemeral-storage)
-                                              are currently supported.'
+                                              requests (limits.cpu, limits.'
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -2174,9 +1639,7 @@ spec:
                                                 type: string
                                               name:
                                                 description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -2192,14 +1655,7 @@ spec:
                                   type: array
                                 envFrom:
                                   description: List of sources to populate environment
-                                    variables in the container. The keys defined within
-                                    a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container
-                                    is starting. When a key exists in multiple sources,
-                                    the value associated with the last source will
-                                    take precedence. Values defined by an Env with
-                                    a duplicate key will take precedence. Cannot be
-                                    updated.
+                                    variables in the container.
                                   items:
                                     description: EnvFromSource represents the source
                                       of a set of ConfigMaps
@@ -2209,9 +1665,7 @@ spec:
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -2228,9 +1682,7 @@ spec:
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -2243,22 +1695,16 @@ spec:
                                   description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                   type: string
                                 imagePullPolicy:
-                                  description: 'Image pull policy. One of Always,
-                                    Never, IfNotPresent. Defaults to Always if :latest
-                                    tag is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                  description: Image pull policy. One of Always, Never,
+                                    IfNotPresent.
                                   type: string
                                 lifecycle:
                                   description: Lifecycle is not allowed for ephemeral
                                     containers.
                                   properties:
                                     postStart:
-                                      description: 'PostStart is called immediately
-                                        after a container is created. If the handler
-                                        fails, the container is terminated and restarted
-                                        according to its restart policy. Other management
-                                        of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: PostStart is called immediately
+                                        after a container is created.
                                       properties:
                                         exec:
                                           description: One and only one of the following
@@ -2266,17 +1712,9 @@ spec:
                                             action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
+                                              description: 'Command is the command
                                                 line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
@@ -2287,9 +1725,7 @@ spec:
                                           properties:
                                             host:
                                               description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2323,8 +1759,7 @@ spec:
                                               - type: string
                                               description: Name or number of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
@@ -2334,10 +1769,8 @@ spec:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -2349,29 +1782,16 @@ spec:
                                               - type: string
                                               description: Number or name of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: 'PreStop is called immediately
-                                        before a container is terminated due to an
-                                        API request or management event such as liveness/startup
-                                        probe failure, preemption, resource contention,
-                                        etc. The handler is not called if the container
-                                        crashes or exits. The reason for termination
-                                        is passed to the handler. The Pod''s termination
-                                        grace period countdown begins before the PreStop
-                                        hooked is executed. Regardless of the outcome
-                                        of the handler, the container will eventually
-                                        terminate within the Pod''s termination grace
-                                        period. Other management of the container
-                                        blocks until the hook completes or until the
-                                        termination grace period is reached. More
-                                        info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: PreStop is called immediately before
+                                        a container is terminated due to an API request
+                                        or management e
                                       properties:
                                         exec:
                                           description: One and only one of the following
@@ -2379,17 +1799,9 @@ spec:
                                             action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
+                                              description: 'Command is the command
                                                 line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
@@ -2400,9 +1812,7 @@ spec:
                                           properties:
                                             host:
                                               description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2436,8 +1846,7 @@ spec:
                                               - type: string
                                               description: Name or number of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
@@ -2447,10 +1856,8 @@ spec:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -2462,8 +1869,7 @@ spec:
                                               - type: string
                                               description: Number or name of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -2480,16 +1886,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -2497,8 +1896,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -2507,8 +1905,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -2538,8 +1935,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -2549,9 +1945,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -2563,15 +1958,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -2583,24 +1975,21 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
                                   description: Name of the ephemeral container specified
-                                    as a DNS_LABEL. This name must be unique among
-                                    all containers, init containers and ephemeral
-                                    containers.
+                                    as a DNS_LABEL.
                                   type: string
                                 ports:
                                   description: Ports are not allowed for ephemeral
@@ -2622,17 +2011,12 @@ spec:
                                       hostPort:
                                         description: Number of port to expose on the
                                           host. If specified, this must be a valid
-                                          port number, 0 < x < 65536. If HostNetwork
-                                          is specified, this must match ContainerPort.
-                                          Most containers do not need this.
+                                          port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       name:
                                         description: If specified, this must be an
                                           IANA_SVC_NAME and unique within the pod.
-                                          Each named port in a pod must have a unique
-                                          name. Name for the port that can be referred
-                                          to by services.
                                         type: string
                                       protocol:
                                         default: TCP
@@ -2653,16 +2037,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -2670,8 +2047,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -2680,8 +2056,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -2711,8 +2086,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -2722,9 +2096,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -2736,15 +2109,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -2756,23 +2126,21 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 resources:
                                   description: Resources are not allowed for ephemeral
-                                    containers. Ephemeral containers use spare resources
-                                    already allocated to the pod.
+                                    containers.
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -2782,7 +2150,7 @@ spec:
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        of compute resources allowed. More info: https://kubernetes.'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -2791,12 +2159,8 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 securityContext:
@@ -2804,19 +2168,13 @@ spec:
                                     ephemeral containers.
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: 'AllowPrivilegeEscalation controls
+                                      description: AllowPrivilegeEscalation controls
                                         whether a process can gain more privileges
-                                        than its parent process. This bool directly
-                                        controls if the no_new_privs flag will be
-                                        set on the container process. AllowPrivilegeEscalation
-                                        is true always when the container is: 1) run
-                                        as Privileged 2) has CAP_SYS_ADMIN'
+                                        than its parent process
                                       type: boolean
                                     capabilities:
                                       description: The capabilities to add/drop when
-                                        running containers. Defaults to the default
-                                        set of capabilities granted by the container
-                                        runtime.
+                                        running containers.
                                       properties:
                                         add:
                                           description: Added capabilities
@@ -2835,17 +2193,10 @@ spec:
                                       type: object
                                     privileged:
                                       description: Run container in privileged mode.
-                                        Processes in privileged containers are essentially
-                                        equivalent to root on the host. Defaults to
-                                        false.
                                       type: boolean
                                     procMount:
                                       description: procMount denotes the type of proc
-                                        mount to use for the containers. The default
-                                        is DefaultProcMount which uses the container
-                                        runtime defaults for readonly paths and masked
-                                        paths. This requires the ProcMountType feature
-                                        flag to be enabled.
+                                        mount to use for the containers.
                                       type: string
                                     readOnlyRootFilesystem:
                                       description: Whether this container has a read-only
@@ -2854,41 +2205,21 @@ spec:
                                     runAsGroup:
                                       description: The GID to run the entrypoint of
                                         the container process. Uses runtime default
-                                        if unset. May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        if unset.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
                                       description: Indicates that the container must
-                                        run as a non-root user. If true, the Kubelet
-                                        will validate the image at runtime to ensure
-                                        that it does not run as UID 0 (root) and fail
-                                        to start the container if it does. If unset
-                                        or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        run as a non-root user.
                                       type: boolean
                                     runAsUser:
                                       description: The UID to run the entrypoint of
-                                        the container process. Defaults to user specified
-                                        in image metadata if unspecified. May also
-                                        be set in PodSecurityContext.  If set in both
-                                        SecurityContext and PodSecurityContext, the
-                                        value specified in SecurityContext takes precedence.
+                                        the container process.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
                                       description: The SELinux context to be applied
-                                        to the container. If unspecified, the container
-                                        runtime will allocate a random SELinux context
-                                        for each container.  May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        to the container.
                                       properties:
                                         level:
                                           description: Level is SELinux level label
@@ -2909,45 +2240,27 @@ spec:
                                       type: object
                                     seccompProfile:
                                       description: The seccomp options to use by this
-                                        container. If seccomp options are provided
-                                        at both the pod & container level, the container
-                                        options override the pod options.
+                                        container.
                                       properties:
                                         localhostProfile:
                                           description: localhostProfile indicates
                                             a profile defined in a file on the node
-                                            should be used. The profile must be preconfigured
-                                            on the node to work. Must be a descending
-                                            path, relative to the kubelet's configured
-                                            seccomp profile location. Must only be
-                                            set if type is "Localhost".
+                                            should be used.
                                           type: string
                                         type:
-                                          description: "type indicates which kind
-                                            of seccomp profile will be applied. Valid
-                                            options are: \n Localhost - a profile
-                                            defined in a file on the node should be
-                                            used. RuntimeDefault - the container runtime
-                                            default profile should be used. Unconfined
-                                            - no profile should be applied."
+                                          description: type indicates which kind of
+                                            seccomp profile will be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
                                       description: The Windows specific settings applied
-                                        to all containers. If unspecified, the options
-                                        from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        to all containers.
                                       properties:
                                         gmsaCredentialSpec:
                                           description: GMSACredentialSpec is where
-                                            the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                            inlines the contents of the GMSA credential
-                                            spec named by the GMSACredentialSpecName
-                                            field.
+                                            the GMSA admission webhook (https://github.
                                           type: string
                                         gmsaCredentialSpecName:
                                           description: GMSACredentialSpecName is the
@@ -2956,12 +2269,6 @@ spec:
                                         runAsUserName:
                                           description: The UserName in Windows to
                                             run the entrypoint of the container process.
-                                            Defaults to the user specified in image
-                                            metadata if unspecified. May also be set
-                                            in PodSecurityContext. If set in both
-                                            SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
                                           type: string
                                       type: object
                                   type: object
@@ -2975,16 +2282,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -2992,8 +2292,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -3002,8 +2301,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -3033,8 +2331,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -3044,9 +2341,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -3058,15 +2354,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -3078,74 +2371,44 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
                                   description: Whether this container should allocate
-                                    a buffer for stdin in the container runtime. If
-                                    this is not set, reads from stdin in the container
-                                    will always result in EOF. Default is false.
+                                    a buffer for stdin in the container runtime.
                                   type: boolean
                                 stdinOnce:
                                   description: Whether the container runtime should
                                     close the stdin channel after it has been opened
-                                    by a single attach. When stdin is true the stdin
-                                    stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is
-                                    opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains
-                                    open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed
-                                    until the container is restarted. If this flag
-                                    is false, a container processes that reads from
-                                    stdin will never receive an EOF. Default is false
+                                    by a single at
                                   type: boolean
                                 targetContainerName:
                                   description: If set, the name of the container from
                                     PodSpec that this ephemeral container targets.
-                                    The ephemeral container will be run in the namespaces
-                                    (IPC, PID, etc) of this container. If not set
-                                    then the ephemeral container is run in whatever
-                                    namespaces are shared for the pod. Note that the
-                                    container runtime must support this feature.
                                   type: string
                                 terminationMessagePath:
                                   description: 'Optional: Path at which the file to
                                     which the container''s termination message will
-                                    be written is mounted into the container''s filesystem.
-                                    Message written is intended to be brief final
-                                    status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than
-                                    4096 bytes. The total message length across all
-                                    containers will be limited to 12kb. Defaults to
-                                    /dev/termination-log. Cannot be updated.'
+                                    be written is mou'
                                   type: string
                                 terminationMessagePolicy:
                                   description: Indicate how the termination message
-                                    should be populated. File will use the contents
-                                    of terminationMessagePath to populate the container
-                                    status message on both success and failure. FallbackToLogsOnError
-                                    will use the last chunk of container log output
-                                    if the termination message file is empty and the
-                                    container exited with an error. The log output
-                                    is limited to 2048 bytes or 80 lines, whichever
-                                    is smaller. Defaults to File. Cannot be updated.
+                                    should be populated.
                                   type: string
                                 tty:
                                   description: Whether this container should allocate
                                     a TTY for itself, also requires 'stdin' to be
-                                    true. Default is false.
+                                    true.
                                   type: boolean
                                 volumeDevices:
                                   description: volumeDevices is the list of block
@@ -3183,9 +2446,7 @@ spec:
                                       mountPropagation:
                                         description: mountPropagation determines how
                                           mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
+                                          and the other way a
                                         type: string
                                       name:
                                         description: This must match the Name of a
@@ -3199,16 +2460,11 @@ spec:
                                       subPath:
                                         description: Path within the volume from which
                                           the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
                                         description: Expanded path within the volume
                                           from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
+                                          be mounted.
                                         type: string
                                     required:
                                     - mountPath
@@ -3216,24 +2472,20 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: Container's working directory. If not
-                                    specified, the container runtime's default will
-                                    be used, which might be configured in the container
-                                    image. Cannot be updated.
+                                  description: Container's working directory.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           hostAliases:
-                            description: HostAliases is an optional list of hosts
-                              and IPs that will be injected into the pod's hosts file
-                              if specified. This is only valid for non-hostNetwork
-                              pods.
+                            description: 'HostAliases is an optional list of hosts
+                              and IPs that will be injected into the pod''s hosts
+                              file if '
                             items:
-                              description: HostAlias holds the mapping between IP
+                              description: 'HostAlias holds the mapping between IP
                                 and hostnames that will be injected as an entry in
-                                the pod's hosts file.
+                                the pod''s '
                               properties:
                                 hostnames:
                                   description: Hostnames for the above IP address.
@@ -3251,9 +2503,7 @@ spec:
                             type: boolean
                           hostNetwork:
                             description: Host networking requested for this pod. Use
-                              the host's network namespace. If this option is set,
-                              the ports that will be used must be specified. Default
-                              to false.
+                              the host's network namespace.
                             type: boolean
                           hostPID:
                             description: 'Use the host''s pid namespace. Optional:
@@ -3261,74 +2511,36 @@ spec:
                             type: boolean
                           hostname:
                             description: Specifies the hostname of the Pod If not
-                              specified, the pod's hostname will be set to a system-defined
-                              value.
+                              specified, the pod's hostname will be set to a system-defin
                             type: string
                           imagePullSecrets:
-                            description: 'ImagePullSecrets is an optional list of
-                              references to secrets in the same namespace to use for
-                              pulling any of the images used by this PodSpec. If specified,
-                              these secrets will be passed to individual puller implementations
-                              for them to use. For example, in the case of docker,
-                              only DockerConfig type secrets are honored. More info:
-                              https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                            description: ImagePullSecrets is an optional list of references
+                              to secrets in the same namespace to use for pulli
                             items:
-                              description: LocalObjectReference contains enough information
-                                to let you locate the referenced object inside the
-                                same namespace.
+                              description: 'LocalObjectReference contains enough information
+                                to let you locate the referenced object inside the '
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.'
                                   type: string
                               type: object
                             type: array
                           initContainers:
-                            description: 'List of initialization containers belonging
-                              to the pod. Init containers are executed in order prior
-                              to containers being started. If any init container fails,
-                              the pod is considered to have failed and is handled
-                              according to its restartPolicy. The name for an init
-                              container or normal container must be unique among all
-                              containers. Init containers may not have Lifecycle actions,
-                              Readiness probes, Liveness probes, or Startup probes.
-                              The resourceRequirements of an init container are taken
-                              into account during scheduling by finding the highest
-                              request/limit for each resource type, and then using
-                              the max of of that value or the sum of the normal containers.
-                              Limits are applied to init containers in a similar fashion.
-                              Init containers cannot currently be added or removed.
-                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                            description: List of initialization containers belonging
+                              to the pod.
                             items:
                               description: A single application container that you
                                 want to run within a pod.
                               properties:
                                 args:
-                                  description: 'Arguments to the entrypoint. The docker
-                                    image''s CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using
-                                    the container''s environment. If a variable cannot
-                                    be resolved, the reference in the input string
-                                    will be unchanged. The $(VAR_NAME) syntax can
-                                    be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: Arguments to the entrypoint. The docker
+                                    image's CMD is used if this is not provided.
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: 'Entrypoint array. Not executed within
-                                    a shell. The docker image''s ENTRYPOINT is used
-                                    if this is not provided. Variable references $(VAR_NAME)
-                                    are expanded using the container''s environment.
-                                    If a variable cannot be resolved, the reference
-                                    in the input string will be unchanged. The $(VAR_NAME)
-                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: Entrypoint array. Not executed within
+                                    a shell.
                                   items:
                                     type: string
                                   type: array
@@ -3344,17 +2556,9 @@ spec:
                                           Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: 'Variable references $(VAR_NAME)
+                                        description: Variable references $(VAR_NAME)
                                           are expanded using the previous defined
-                                          environment variables in the container and
-                                          any service environment variables. If a
-                                          variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Defaults to
-                                          "".'
+                                          environment variables in the
                                         type: string
                                       valueFrom:
                                         description: Source for the environment variable's
@@ -3368,9 +2572,7 @@ spec:
                                                 type: string
                                               name:
                                                 description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -3382,9 +2584,7 @@ spec:
                                           fieldRef:
                                             description: 'Selects a field of the pod:
                                               supports metadata.name, metadata.namespace,
-                                              `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                              spec.nodeName, spec.serviceAccountName,
-                                              status.hostIP, status.podIP, status.podIPs.'
+                                              `metadata.'
                                             properties:
                                               apiVersion:
                                                 description: Version of the schema
@@ -3401,10 +2601,7 @@ spec:
                                           resourceFieldRef:
                                             description: 'Selects a resource of the
                                               container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              limits.ephemeral-storage, requests.cpu,
-                                              requests.memory and requests.ephemeral-storage)
-                                              are currently supported.'
+                                              requests (limits.cpu, limits.'
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -3437,9 +2634,7 @@ spec:
                                                 type: string
                                               name:
                                                 description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3455,14 +2650,7 @@ spec:
                                   type: array
                                 envFrom:
                                   description: List of sources to populate environment
-                                    variables in the container. The keys defined within
-                                    a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container
-                                    is starting. When a key exists in multiple sources,
-                                    the value associated with the last source will
-                                    take precedence. Values defined by an Env with
-                                    a duplicate key will take precedence. Cannot be
-                                    updated.
+                                    variables in the container.
                                   items:
                                     description: EnvFromSource represents the source
                                       of a set of ConfigMaps
@@ -3472,9 +2660,7 @@ spec:
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -3491,9 +2677,7 @@ spec:
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -3503,29 +2687,20 @@ spec:
                                     type: object
                                   type: array
                                 image:
-                                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config
-                                    management to default or override container images
-                                    in workload controllers like Deployments and StatefulSets.'
+                                  description: 'Docker image name. More info: https://kubernetes.'
                                   type: string
                                 imagePullPolicy:
-                                  description: 'Image pull policy. One of Always,
-                                    Never, IfNotPresent. Defaults to Always if :latest
-                                    tag is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                  description: Image pull policy. One of Always, Never,
+                                    IfNotPresent.
                                   type: string
                                 lifecycle:
                                   description: Actions that the management system
                                     should take in response to container lifecycle
-                                    events. Cannot be updated.
+                                    events.
                                   properties:
                                     postStart:
-                                      description: 'PostStart is called immediately
-                                        after a container is created. If the handler
-                                        fails, the container is terminated and restarted
-                                        according to its restart policy. Other management
-                                        of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: PostStart is called immediately
+                                        after a container is created.
                                       properties:
                                         exec:
                                           description: One and only one of the following
@@ -3533,17 +2708,9 @@ spec:
                                             action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
+                                              description: 'Command is the command
                                                 line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
@@ -3554,9 +2721,7 @@ spec:
                                           properties:
                                             host:
                                               description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3590,8 +2755,7 @@ spec:
                                               - type: string
                                               description: Name or number of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
@@ -3601,10 +2765,8 @@ spec:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3616,29 +2778,16 @@ spec:
                                               - type: string
                                               description: Number or name of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: 'PreStop is called immediately
-                                        before a container is terminated due to an
-                                        API request or management event such as liveness/startup
-                                        probe failure, preemption, resource contention,
-                                        etc. The handler is not called if the container
-                                        crashes or exits. The reason for termination
-                                        is passed to the handler. The Pod''s termination
-                                        grace period countdown begins before the PreStop
-                                        hooked is executed. Regardless of the outcome
-                                        of the handler, the container will eventually
-                                        terminate within the Pod''s termination grace
-                                        period. Other management of the container
-                                        blocks until the hook completes or until the
-                                        termination grace period is reached. More
-                                        info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: PreStop is called immediately before
+                                        a container is terminated due to an API request
+                                        or management e
                                       properties:
                                         exec:
                                           description: One and only one of the following
@@ -3646,17 +2795,9 @@ spec:
                                             action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
+                                              description: 'Command is the command
                                                 line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
@@ -3667,9 +2808,7 @@ spec:
                                           properties:
                                             host:
                                               description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3703,8 +2842,7 @@ spec:
                                               - type: string
                                               description: Name or number of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
@@ -3714,10 +2852,8 @@ spec:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3729,8 +2865,7 @@ spec:
                                               - type: string
                                               description: Number or name of the port
                                                 to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -3738,9 +2873,8 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: 'Periodic probe of container liveness.
+                                  description: Periodic probe of container liveness.
                                     Container will be restarted if the probe fails.
-                                    Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   properties:
                                     exec:
                                       description: One and only one of the following
@@ -3748,16 +2882,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -3765,8 +2892,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -3775,8 +2901,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -3806,8 +2931,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -3817,9 +2941,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -3831,15 +2954,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -3851,33 +2971,24 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
                                   description: Name of the container specified as
-                                    a DNS_LABEL. Each container in a pod must have
-                                    a unique name (DNS_LABEL). Cannot be updated.
+                                    a DNS_LABEL.
                                   type: string
                                 ports:
                                   description: List of ports to expose from the container.
-                                    Exposing a port here gives the system additional
-                                    information about the network connections a container
-                                    uses, but is primarily informational. Not specifying
-                                    a port here DOES NOT prevent that port from being
-                                    exposed. Any port which is listening on the default
-                                    "0.0.0.0" address inside a container will be accessible
-                                    from the network. Cannot be updated.
                                   items:
                                     description: ContainerPort represents a network
                                       port in a single container.
@@ -3895,17 +3006,12 @@ spec:
                                       hostPort:
                                         description: Number of port to expose on the
                                           host. If specified, this must be a valid
-                                          port number, 0 < x < 65536. If HostNetwork
-                                          is specified, this must match ContainerPort.
-                                          Most containers do not need this.
+                                          port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       name:
                                         description: If specified, this must be an
                                           IANA_SVC_NAME and unique within the pod.
-                                          Each named port in a pod must have a unique
-                                          name. Name for the port that can be referred
-                                          to by services.
                                         type: string
                                       protocol:
                                         default: TCP
@@ -3921,10 +3027,8 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: 'Periodic probe of container service
-                                    readiness. Container will be removed from service
-                                    endpoints if the probe fails. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: Periodic probe of container service
+                                    readiness.
                                   properties:
                                     exec:
                                       description: One and only one of the following
@@ -3932,16 +3036,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -3949,8 +3046,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -3959,8 +3055,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -3990,8 +3085,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -4001,9 +3095,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -4015,15 +3108,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -4035,22 +3125,21 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 resources:
                                   description: 'Compute Resources required by this
-                                    container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    container. Cannot be updated. More info: https://kubernetes.'
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -4060,7 +3149,7 @@ spec:
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        of compute resources allowed. More info: https://kubernetes.'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -4069,33 +3158,22 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 securityContext:
                                   description: 'Security options the pod should run
-                                    with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    with. More info: https://kubernetes.'
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: 'AllowPrivilegeEscalation controls
+                                      description: AllowPrivilegeEscalation controls
                                         whether a process can gain more privileges
-                                        than its parent process. This bool directly
-                                        controls if the no_new_privs flag will be
-                                        set on the container process. AllowPrivilegeEscalation
-                                        is true always when the container is: 1) run
-                                        as Privileged 2) has CAP_SYS_ADMIN'
+                                        than its parent process
                                       type: boolean
                                     capabilities:
                                       description: The capabilities to add/drop when
-                                        running containers. Defaults to the default
-                                        set of capabilities granted by the container
-                                        runtime.
+                                        running containers.
                                       properties:
                                         add:
                                           description: Added capabilities
@@ -4114,17 +3192,10 @@ spec:
                                       type: object
                                     privileged:
                                       description: Run container in privileged mode.
-                                        Processes in privileged containers are essentially
-                                        equivalent to root on the host. Defaults to
-                                        false.
                                       type: boolean
                                     procMount:
                                       description: procMount denotes the type of proc
-                                        mount to use for the containers. The default
-                                        is DefaultProcMount which uses the container
-                                        runtime defaults for readonly paths and masked
-                                        paths. This requires the ProcMountType feature
-                                        flag to be enabled.
+                                        mount to use for the containers.
                                       type: string
                                     readOnlyRootFilesystem:
                                       description: Whether this container has a read-only
@@ -4133,41 +3204,21 @@ spec:
                                     runAsGroup:
                                       description: The GID to run the entrypoint of
                                         the container process. Uses runtime default
-                                        if unset. May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        if unset.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
                                       description: Indicates that the container must
-                                        run as a non-root user. If true, the Kubelet
-                                        will validate the image at runtime to ensure
-                                        that it does not run as UID 0 (root) and fail
-                                        to start the container if it does. If unset
-                                        or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        run as a non-root user.
                                       type: boolean
                                     runAsUser:
                                       description: The UID to run the entrypoint of
-                                        the container process. Defaults to user specified
-                                        in image metadata if unspecified. May also
-                                        be set in PodSecurityContext.  If set in both
-                                        SecurityContext and PodSecurityContext, the
-                                        value specified in SecurityContext takes precedence.
+                                        the container process.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
                                       description: The SELinux context to be applied
-                                        to the container. If unspecified, the container
-                                        runtime will allocate a random SELinux context
-                                        for each container.  May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        to the container.
                                       properties:
                                         level:
                                           description: Level is SELinux level label
@@ -4188,45 +3239,27 @@ spec:
                                       type: object
                                     seccompProfile:
                                       description: The seccomp options to use by this
-                                        container. If seccomp options are provided
-                                        at both the pod & container level, the container
-                                        options override the pod options.
+                                        container.
                                       properties:
                                         localhostProfile:
                                           description: localhostProfile indicates
                                             a profile defined in a file on the node
-                                            should be used. The profile must be preconfigured
-                                            on the node to work. Must be a descending
-                                            path, relative to the kubelet's configured
-                                            seccomp profile location. Must only be
-                                            set if type is "Localhost".
+                                            should be used.
                                           type: string
                                         type:
-                                          description: "type indicates which kind
-                                            of seccomp profile will be applied. Valid
-                                            options are: \n Localhost - a profile
-                                            defined in a file on the node should be
-                                            used. RuntimeDefault - the container runtime
-                                            default profile should be used. Unconfined
-                                            - no profile should be applied."
+                                          description: type indicates which kind of
+                                            seccomp profile will be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
                                       description: The Windows specific settings applied
-                                        to all containers. If unspecified, the options
-                                        from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        to all containers.
                                       properties:
                                         gmsaCredentialSpec:
                                           description: GMSACredentialSpec is where
-                                            the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                            inlines the contents of the GMSA credential
-                                            spec named by the GMSACredentialSpecName
-                                            field.
+                                            the GMSA admission webhook (https://github.
                                           type: string
                                         gmsaCredentialSpecName:
                                           description: GMSACredentialSpecName is the
@@ -4235,27 +3268,12 @@ spec:
                                         runAsUserName:
                                           description: The UserName in Windows to
                                             run the entrypoint of the container process.
-                                            Defaults to the user specified in image
-                                            metadata if unspecified. May also be set
-                                            in PodSecurityContext. If set in both
-                                            SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: 'StartupProbe indicates that the Pod
-                                    has successfully initialized. If specified, no
-                                    other probes are executed until this completes
-                                    successfully. If this probe fails, the Pod will
-                                    be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters
-                                    at the beginning of a Pod''s lifecycle, when it
-                                    might take a long time to load data or warm a
-                                    cache, than during steady-state operation. This
-                                    cannot be updated. This is a beta feature enabled
-                                    by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: StartupProbe indicates that the Pod
+                                    has successfully initialized.
                                   properties:
                                     exec:
                                       description: One and only one of the following
@@ -4263,16 +3281,9 @@ spec:
                                         to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
+                                          description: 'Command is the command line
                                             to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
@@ -4280,8 +3291,7 @@ spec:
                                     failureThreshold:
                                       description: Minimum consecutive failures for
                                         the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
@@ -4290,8 +3300,7 @@ spec:
                                       properties:
                                         host:
                                           description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
                                           description: Custom headers to set in the
@@ -4321,8 +3330,7 @@ spec:
                                           - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
                                           description: Scheme to use for connecting
@@ -4332,9 +3340,8 @@ spec:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
+                                      description: Number of seconds after the container
                                         has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       format: int32
                                       type: integer
                                     periodSeconds:
@@ -4346,15 +3353,12 @@ spec:
                                     successThreshold:
                                       description: Minimum consecutive successes for
                                         the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -4366,65 +3370,40 @@ spec:
                                           - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
                                   description: Whether this container should allocate
-                                    a buffer for stdin in the container runtime. If
-                                    this is not set, reads from stdin in the container
-                                    will always result in EOF. Default is false.
+                                    a buffer for stdin in the container runtime.
                                   type: boolean
                                 stdinOnce:
                                   description: Whether the container runtime should
                                     close the stdin channel after it has been opened
-                                    by a single attach. When stdin is true the stdin
-                                    stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is
-                                    opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains
-                                    open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed
-                                    until the container is restarted. If this flag
-                                    is false, a container processes that reads from
-                                    stdin will never receive an EOF. Default is false
+                                    by a single at
                                   type: boolean
                                 terminationMessagePath:
                                   description: 'Optional: Path at which the file to
                                     which the container''s termination message will
-                                    be written is mounted into the container''s filesystem.
-                                    Message written is intended to be brief final
-                                    status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than
-                                    4096 bytes. The total message length across all
-                                    containers will be limited to 12kb. Defaults to
-                                    /dev/termination-log. Cannot be updated.'
+                                    be written is mou'
                                   type: string
                                 terminationMessagePolicy:
                                   description: Indicate how the termination message
-                                    should be populated. File will use the contents
-                                    of terminationMessagePath to populate the container
-                                    status message on both success and failure. FallbackToLogsOnError
-                                    will use the last chunk of container log output
-                                    if the termination message file is empty and the
-                                    container exited with an error. The log output
-                                    is limited to 2048 bytes or 80 lines, whichever
-                                    is smaller. Defaults to File. Cannot be updated.
+                                    should be populated.
                                   type: string
                                 tty:
                                   description: Whether this container should allocate
                                     a TTY for itself, also requires 'stdin' to be
-                                    true. Default is false.
+                                    true.
                                   type: boolean
                                 volumeDevices:
                                   description: volumeDevices is the list of block
@@ -4462,9 +3441,7 @@ spec:
                                       mountPropagation:
                                         description: mountPropagation determines how
                                           mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
+                                          and the other way a
                                         type: string
                                       name:
                                         description: This must match the Name of a
@@ -4478,16 +3455,11 @@ spec:
                                       subPath:
                                         description: Path within the volume from which
                                           the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
                                         description: Expanded path within the volume
                                           from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
+                                          be mounted.
                                         type: string
                                     required:
                                     - mountPath
@@ -4495,10 +3467,7 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: Container's working directory. If not
-                                    specified, the container runtime's default will
-                                    be used, which might be configured in the container
-                                    image. Cannot be updated.
+                                  description: Container's working directory.
                                   type: string
                               required:
                               - name
@@ -4506,17 +3475,13 @@ spec:
                             type: array
                           nodeName:
                             description: NodeName is a request to schedule this pod
-                              onto a specific node. If it is non-empty, the scheduler
-                              simply schedules this pod onto that node, assuming that
-                              it fits resource requirements.
+                              onto a specific node.
                             type: string
                           nodeSelector:
                             additionalProperties:
                               type: string
-                            description: 'NodeSelector is a selector which must be
-                              true for the pod to fit on a node. Selector which must
-                              match a node''s labels for the pod to be scheduled on
-                              that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                            description: NodeSelector is a selector which must be
+                              true for the pod to fit on a node.
                             type: object
                           overhead:
                             additionalProperties:
@@ -4525,52 +3490,24 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Overhead represents the resource overhead
+                            description: Overhead represents the resource overhead
                               associated with running a pod for a given RuntimeClass.
-                              This field will be autopopulated at admission time by
-                              the RuntimeClass admission controller. If the RuntimeClass
-                              admission controller is enabled, overhead must not be
-                              set in Pod create requests. The RuntimeClass admission
-                              controller will reject Pod create requests which have
-                              the overhead already set. If RuntimeClass is configured
-                              and selected in the PodSpec, Overhead will be set to
-                              the value defined in the corresponding RuntimeClass,
-                              otherwise it will remain unset and treated as zero.
-                              More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                              This field is alpha-level as of Kubernetes v1.16, and
-                              is only honored by servers that enable the PodOverhead
-                              feature.'
                             type: object
                           preemptionPolicy:
                             description: PreemptionPolicy is the Policy for preempting
-                              pods with lower priority. One of Never, PreemptLowerPriority.
-                              Defaults to PreemptLowerPriority if unset. This field
-                              is beta-level, gated by the NonPreemptingPriority feature-gate.
+                              pods with lower priority.
                             type: string
                           priority:
                             description: The priority value. Various system components
-                              use this field to find the priority of the pod. When
-                              Priority Admission Controller is enabled, it prevents
-                              users from setting this field. The admission controller
-                              populates this field from PriorityClassName. The higher
-                              the value, the higher the priority.
+                              use this field to find the priority of the pod.
                             format: int32
                             type: integer
                           priorityClassName:
                             description: If specified, indicates the pod's priority.
-                              "system-node-critical" and "system-cluster-critical"
-                              are two special keywords which indicate the highest
-                              priorities with the former being the highest priority.
-                              Any other name must be defined by creating a PriorityClass
-                              object with that name. If not specified, the pod priority
-                              will be default or zero if there is no default.
                             type: string
                           readinessGates:
-                            description: 'If specified, all readiness gates will be
-                              evaluated for pod readiness. A pod is ready when all
-                              its containers are ready AND all conditions specified
-                              in the readiness gates have status equal to "True" More
-                              info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                            description: If specified, all readiness gates will be
+                              evaluated for pod readiness.
                             items:
                               description: PodReadinessGate contains the reference
                                 to a pod condition
@@ -4584,89 +3521,48 @@ spec:
                               type: object
                             type: array
                           restartPolicy:
-                            description: 'Restart policy for all containers within
-                              the pod. One of Always, OnFailure, Never. Default to
-                              Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                            description: Restart policy for all containers within
+                              the pod. One of Always, OnFailure, Never.
                             type: string
                           runtimeClassName:
-                            description: 'RuntimeClassName refers to a RuntimeClass
-                              object in the node.k8s.io group, which should be used
-                              to run this pod.  If no RuntimeClass resource matches
-                              the named class, the pod will not be run. If unset or
-                              empty, the "legacy" RuntimeClass will be used, which
-                              is an implicit class with an empty definition that uses
-                              the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                              This is a beta feature as of Kubernetes v1.14.'
+                            description: RuntimeClassName refers to a RuntimeClass
+                              object in the node.k8s.
                             type: string
                           schedulerName:
                             description: If specified, the pod will be dispatched
-                              by specified scheduler. If not specified, the pod will
-                              be dispatched by default scheduler.
+                              by specified scheduler.
                             type: string
                           securityContext:
-                            description: 'SecurityContext holds pod-level security
-                              attributes and common container settings. Optional:
-                              Defaults to empty.  See type description for default
-                              values of each field.'
+                            description: SecurityContext holds pod-level security
+                              attributes and common container settings.
                             properties:
                               fsGroup:
-                                description: "A special supplemental group that applies
-                                  to all containers in a pod. Some volume types allow
-                                  the Kubelet to change the ownership of that volume
-                                  to be owned by the pod: \n 1. The owning GID will
-                                  be the FSGroup 2. The setgid bit is set (new files
-                                  created in the volume will be owned by FSGroup)
-                                  3. The permission bits are OR'd with rw-rw---- \n
-                                  If unset, the Kubelet will not modify the ownership
-                                  and permissions of any volume."
+                                description: A special supplemental group that applies
+                                  to all containers in a pod.
                                 format: int64
                                 type: integer
                               fsGroupChangePolicy:
-                                description: 'fsGroupChangePolicy defines behavior
+                                description: fsGroupChangePolicy defines behavior
                                   of changing ownership and permission of the volume
-                                  before being exposed inside Pod. This field will
-                                  only apply to volume types which support fsGroup
-                                  based ownership(and permissions). It will have no
-                                  effect on ephemeral volume types such as: secret,
-                                  configmaps and emptydir. Valid values are "OnRootMismatch"
-                                  and "Always". If not specified defaults to "Always".'
+                                  before being
                                 type: string
                               runAsGroup:
                                 description: The GID to run the entrypoint of the
                                   container process. Uses runtime default if unset.
-                                  May also be set in SecurityContext.  If set in both
-                                  SecurityContext and PodSecurityContext, the value
-                                  specified in SecurityContext takes precedence for
-                                  that container.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
                                 description: Indicates that the container must run
-                                  as a non-root user. If true, the Kubelet will validate
-                                  the image at runtime to ensure that it does not
-                                  run as UID 0 (root) and fail to start the container
-                                  if it does. If unset or false, no such validation
-                                  will be performed. May also be set in SecurityContext.  If
-                                  set in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence.
+                                  as a non-root user.
                                 type: boolean
                               runAsUser:
                                 description: The UID to run the entrypoint of the
-                                  container process. Defaults to user specified in
-                                  image metadata if unspecified. May also be set in
-                                  SecurityContext.  If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence for that container.
+                                  container process.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
                                 description: The SELinux context to be applied to
-                                  all containers. If unspecified, the container runtime
-                                  will allocate a random SELinux context for each
-                                  container.  May also be set in SecurityContext.  If
-                                  set in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence
-                                  for that container.
+                                  all containers.
                                 properties:
                                   level:
                                     description: Level is SELinux level label that
@@ -4692,35 +3588,25 @@ spec:
                                   localhostProfile:
                                     description: localhostProfile indicates a profile
                                       defined in a file on the node should be used.
-                                      The profile must be preconfigured on the node
-                                      to work. Must be a descending path, relative
-                                      to the kubelet's configured seccomp profile
-                                      location. Must only be set if type is "Localhost".
                                     type: string
                                   type:
-                                    description: "type indicates which kind of seccomp
-                                      profile will be applied. Valid options are:
-                                      \n Localhost - a profile defined in a file on
-                                      the node should be used. RuntimeDefault - the
-                                      container runtime default profile should be
-                                      used. Unconfined - no profile should be applied."
+                                    description: type indicates which kind of seccomp
+                                      profile will be applied.
                                     type: string
                                 required:
                                 - type
                                 type: object
                               supplementalGroups:
-                                description: A list of groups applied to the first
+                                description: 'A list of groups applied to the first
                                   process run in each container, in addition to the
-                                  container's primary GID.  If unspecified, no groups
-                                  will be added to any container.
+                                  container''s '
                                 items:
                                   format: int64
                                   type: integer
                                 type: array
                               sysctls:
                                 description: Sysctls hold a list of namespaced sysctls
-                                  used for the pod. Pods with unsupported sysctls
-                                  (by the container runtime) might fail to launch.
+                                  used for the pod.
                                 items:
                                   description: Sysctl defines a kernel parameter to
                                     be set
@@ -4738,16 +3624,11 @@ spec:
                                 type: array
                               windowsOptions:
                                 description: The Windows specific settings applied
-                                  to all containers. If unspecified, the options within
-                                  a container's SecurityContext will be used. If set
-                                  in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence.
+                                  to all containers.
                                 properties:
                                   gmsaCredentialSpec:
                                     description: GMSACredentialSpec is where the GMSA
-                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                      inlines the contents of the GMSA credential
-                                      spec named by the GMSACredentialSpecName field.
+                                      admission webhook (https://github.
                                     type: string
                                   gmsaCredentialSpecName:
                                     description: GMSACredentialSpecName is the name
@@ -4755,122 +3636,75 @@ spec:
                                     type: string
                                   runAsUserName:
                                     description: The UserName in Windows to run the
-                                      entrypoint of the container process. Defaults
-                                      to the user specified in image metadata if unspecified.
-                                      May also be set in PodSecurityContext. If set
-                                      in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence.
+                                      entrypoint of the container process.
                                     type: string
                                 type: object
                             type: object
                           serviceAccount:
-                            description: 'DeprecatedServiceAccount is a depreciated
-                              alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                              instead.'
+                            description: DeprecatedServiceAccount is a depreciated
+                              alias for ServiceAccountName.
                             type: string
                           serviceAccountName:
-                            description: 'ServiceAccountName is the name of the ServiceAccount
-                              to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                            description: ServiceAccountName is the name of the ServiceAccount
+                              to use to run this pod.
                             type: string
                           setHostnameAsFQDN:
                             description: If true the pod's hostname will be configured
-                              as the pod's FQDN, rather than the leaf name (the default).
-                              In Linux containers, this means setting the FQDN in
-                              the hostname field of the kernel (the nodename field
-                              of struct utsname). In Windows containers, this means
-                              setting the registry value of hostname for the registry
-                              key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                              to FQDN. If a pod does not have FQDN, this has no effect.
-                              Default to false.
+                              as the pod's FQDN, rather than the leaf name (the defa
                             type: boolean
                           shareProcessNamespace:
-                            description: 'Share a single process namespace between
-                              all of the containers in a pod. When this is set containers
-                              will be able to view and signal processes from other
-                              containers in the same pod, and the first process in
-                              each container will not be assigned PID 1. HostPID and
-                              ShareProcessNamespace cannot both be set. Optional:
-                              Default to false.'
+                            description: Share a single process namespace between
+                              all of the containers in a pod.
                             type: boolean
                           subdomain:
                             description: If specified, the fully qualified Pod hostname
-                              will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                              domain>". If not specified, the pod will not have a
-                              domainname at all.
+                              will be "<hostname>.<subdomain>.<pod namespace>.svc.
                             type: string
                           terminationGracePeriodSeconds:
                             description: Optional duration in seconds the pod needs
-                              to terminate gracefully. May be decreased in delete
-                              request. Value must be non-negative integer. The value
-                              zero indicates delete immediately. If this value is
-                              nil, the default grace period will be used instead.
-                              The grace period is the duration in seconds after the
-                              processes running in the pod are sent a termination
-                              signal and the time when the processes are forcibly
-                              halted with a kill signal. Set this value longer than
-                              the expected cleanup time for your process. Defaults
-                              to 30 seconds.
+                              to terminate gracefully.
                             format: int64
                             type: integer
                           tolerations:
                             description: If specified, the pod's tolerations.
                             items:
                               description: The pod this Toleration is attached to
-                                tolerates any taint that matches the triple <key,value,effect>
-                                using the matching operator <operator>.
+                                tolerates any taint that matches the triple <key,value,effect
                               properties:
                                 effect:
                                   description: Effect indicates the taint effect to
-                                    match. Empty means match all taint effects. When
-                                    specified, allowed values are NoSchedule, PreferNoSchedule
-                                    and NoExecute.
+                                    match. Empty means match all taint effects.
                                   type: string
                                 key:
                                   description: Key is the taint key that the toleration
                                     applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists;
-                                    this combination means to match all values and
-                                    all keys.
                                   type: string
                                 operator:
                                   description: Operator represents a key's relationship
                                     to the value. Valid operators are Exists and Equal.
-                                    Defaults to Equal. Exists is equivalent to wildcard
-                                    for value, so that a pod can tolerate all taints
-                                    of a particular category.
                                   type: string
                                 tolerationSeconds:
                                   description: TolerationSeconds represents the period
                                     of time the toleration (which must be of effect
-                                    NoExecute, otherwise this field is ignored) tolerates
-                                    the taint. By default, it is not set, which means
-                                    tolerate the taint forever (do not evict). Zero
-                                    and negative values will be treated as 0 (evict
-                                    immediately) by the system.
+                                    NoExecute, o
                                   format: int64
                                   type: integer
                                 value:
                                   description: Value is the taint value the toleration
-                                    matches to. If the operator is Exists, the value
-                                    should be empty, otherwise just a regular string.
+                                    matches to.
                                   type: string
                               type: object
                             type: array
                           topologySpreadConstraints:
                             description: TopologySpreadConstraints describes how a
                               group of pods ought to spread across topology domains.
-                              Scheduler will schedule pods in a way which abides by
-                              the constraints. All topologySpreadConstraints are ANDed.
                             items:
                               description: TopologySpreadConstraint specifies how
                                 to spread matching pods among the given topology.
                               properties:
                                 labelSelector:
                                   description: LabelSelector is used to find matching
-                                    pods. Pods that match this label selector are
-                                    counted to determine the number of pods in their
-                                    corresponding topology domain.
+                                    pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -4879,8 +3713,7 @@ spec:
                                       items:
                                         description: A label selector requirement
                                           is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                          and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that
@@ -4888,18 +3721,11 @@ spec:
                                             type: string
                                           operator:
                                             description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                              relationship to a set of values.
                                             type: string
                                           values:
                                             description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                              values.
                                             items:
                                               type: string
                                             type: array
@@ -4912,60 +3738,21 @@ spec:
                                       additionalProperties:
                                         type: string
                                       description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                        pairs.
                                       type: object
                                   type: object
                                 maxSkew:
-                                  description: 'MaxSkew describes the degree to which
-                                    pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                    it is the maximum permitted difference between
-                                    the number of matching pods in the target topology
-                                    and the global minimum. For example, in a 3-zone
-                                    cluster, MaxSkew is set to 1, and pods with the
-                                    same labelSelector spread as 1/1/0: | zone1 |
-                                    zone2 | zone3 | |   P   |   P   |       | - if
-                                    MaxSkew is 1, incoming pod can only be scheduled
-                                    to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                                    would make the ActualSkew(2-0) on zone1(zone2)
-                                    violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                    pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                    it is used to give higher precedence to topologies
-                                    that satisfy it. It''s a required field. Default
-                                    value is 1 and 0 is not allowed.'
+                                  description: MaxSkew describes the degree to which
+                                    pods may be unevenly distributed.
                                   format: int32
                                   type: integer
                                 topologyKey:
                                   description: TopologyKey is the key of node labels.
-                                    Nodes that have a label with this key and identical
-                                    values are considered to be in the same topology.
-                                    We consider each <key, value> as a "bucket", and
-                                    try to put balanced number of pods into each bucket.
-                                    It's a required field.
                                   type: string
                                 whenUnsatisfiable:
-                                  description: 'WhenUnsatisfiable indicates how to
-                                    deal with a pod if it doesn''t satisfy the spread
-                                    constraint. - DoNotSchedule (default) tells the
-                                    scheduler not to schedule it. - ScheduleAnyway
-                                    tells the scheduler to schedule the pod in any
-                                    location,   but giving higher precedence to topologies
-                                    that would help reduce the   skew. A constraint
-                                    is considered "Unsatisfiable" for an incoming
-                                    pod if and only if every possible node assigment
-                                    for that pod would violate "MaxSkew" on some topology.
-                                    For example, in a 3-zone cluster, MaxSkew is set
-                                    to 1, and pods with the same labelSelector spread
-                                    as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                                    If WhenUnsatisfiable is set to DoNotSchedule,
-                                    incoming pod can only be scheduled to zone2(zone3)
-                                    to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
-                                    satisfies MaxSkew(1). In other words, the cluster
-                                    can still be imbalanced, but scheduler won''t
-                                    make it *more* imbalanced. It''s a required field.'
+                                  description: WhenUnsatisfiable indicates how to
+                                    deal with a pod if it doesn't satisfy the spread
+                                    constraint.
                                   type: string
                               required:
                               - maxSkew
@@ -4978,48 +3765,34 @@ spec:
                             - whenUnsatisfiable
                             x-kubernetes-list-type: map
                           volumes:
-                            description: 'List of volumes that can be mounted by containers
-                              belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                            description: List of volumes that can be mounted by containers
+                              belonging to the pod.
                             items:
                               description: Volume represents a named volume in a pod
                                 that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'AWSElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: AWSElasticBlockStore represents an
+                                    AWS Disk resource that is attached to a kubelet's
+                                    host machine an
                                   properties:
                                     fsType:
-                                      description: 'Filesystem type of the volume
-                                        that you want to mount. Tip: Ensure that the
-                                        filesystem type is supported by the host operating
-                                        system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                        inferred to be "ext4" if unspecified. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                      description: Filesystem type of the volume that
+                                        you want to mount.
                                       type: string
                                     partition:
-                                      description: 'The partition in the volume that
-                                        you want to mount. If omitted, the default
-                                        is to mount by volume name. Examples: For
-                                        volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
+                                      description: The partition in the volume that
+                                        you want to mount.
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'Specify "true" to force and set
+                                      description: Specify "true" to force and set
                                         the ReadOnly property in VolumeMounts to "true".
-                                        If omitted, the default is "false". More info:
-                                        https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
                                       description: 'Unique ID of the persistent disk
                                         resource in AWS (Amazon EBS volume). More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        info: https://kubernetes.'
                                       type: string
                                   required:
                                   - volumeID
@@ -5043,15 +3816,12 @@ spec:
                                     fsType:
                                       description: Filesystem type to mount. Must
                                         be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
+                                        operating system. Ex.
                                       type: string
                                     kind:
                                       description: 'Expected values Shared: multiple
                                         blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
+                                        single blob disk per sto'
                                       type: string
                                     readOnly:
                                       description: Defaults to false (read/write).
@@ -5089,7 +3859,7 @@ spec:
                                   properties:
                                     monitors:
                                       description: 'Required: Monitors is a collection
-                                        of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        of Ceph monitors More info: https://examples.k8s.'
                                       items:
                                         type: string
                                       type: array
@@ -5099,50 +3869,40 @@ spec:
                                         is /'
                                       type: string
                                     readOnly:
-                                      description: 'Optional: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      description: 'Optional: Defaults to false (read/write).'
                                       type: boolean
                                     secretFile:
                                       description: 'Optional: SecretFile is the path
-                                        to key ring for User, default is /etc/ceph/user.secret
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        to key ring for User, default is /etc/ceph/user.'
                                       type: string
                                     secretRef:
                                       description: 'Optional: SecretRef is reference
                                         to the authentication secret for User, default
-                                        is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        is empty.'
                                       properties:
                                         name:
                                           description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     user:
                                       description: 'Optional: User is the rados user
-                                        name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        name, default is admin More info: https://examples.k8s.'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'Cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: Cinder represents a cinder volume attached
+                                    and mounted on kubelets host machine.
                                   properties:
                                     fsType:
-                                      description: 'Filesystem type to mount. Must
+                                      description: Filesystem type to mount. Must
                                         be a filesystem type supported by the host
-                                        operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        operating system.
                                       type: string
                                     readOnly:
-                                      description: 'Optional: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      description: 'Optional: Defaults to false (read/write).'
                                       type: boolean
                                     secretRef:
                                       description: 'Optional: points to a secret object
@@ -5150,14 +3910,12 @@ spec:
                                       properties:
                                         name:
                                           description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     volumeID:
                                       description: 'volume id used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        volume in cinder. More info: https://examples.k8s.'
                                       type: string
                                   required:
                                   - volumeID
@@ -5168,30 +3926,13 @@ spec:
                                   properties:
                                     defaultMode:
                                       description: 'Optional: mode bits used to set
-                                        permissions on created files by default. Must
-                                        be an octal value between 0000 and 0777 or
-                                        a decimal value between 0 and 511. YAML accepts
-                                        both octal and decimal values, JSON requires
-                                        decimal values for mode bits. Defaults to
-                                        0644. Directories within the path are not
-                                        affected by this setting. This might be in
-                                        conflict with other options that affect the
-                                        file mode, like fsGroup, and the result can
-                                        be other mode bits set.'
+                                        permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: If unspecified, each key-value
+                                      description: 'If unspecified, each key-value
                                         pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
+                                        will be projected '
                                       items:
                                         description: Maps a string key to a path within
                                           a volume.
@@ -5201,25 +3942,13 @@ spec:
                                             type: string
                                           mode:
                                             description: 'Optional: mode bits used
-                                              to set permissions on this file. Must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
+                                              to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
                                             description: The relative path of the
                                               file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
+                                              absolute path.
                                             type: string
                                         required:
                                         - key
@@ -5228,9 +3957,7 @@ spec:
                                       type: array
                                     name:
                                       description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                        https://kubernetes.'
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -5240,36 +3967,24 @@ spec:
                                 csi:
                                   description: CSI (Container Storage Interface) represents
                                     ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
+                                    C
                                   properties:
                                     driver:
                                       description: Driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
+                                        that handles this volume.
                                       type: string
                                     fsType:
                                       description: Filesystem type to mount. Ex. "ext4",
-                                        "xfs", "ntfs". If not provided, the empty
-                                        value is passed to the associated CSI driver
-                                        which will determine the default filesystem
-                                        to apply.
+                                        "xfs", "ntfs".
                                       type: string
                                     nodePublishSecretRef:
                                       description: NodePublishSecretRef is a reference
                                         to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
+                                        information to pass to
                                       properties:
                                         name:
                                           description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     readOnly:
@@ -5281,8 +3996,6 @@ spec:
                                         type: string
                                       description: VolumeAttributes stores driver-specific
                                         properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
@@ -5293,17 +4006,7 @@ spec:
                                   properties:
                                     defaultMode:
                                       description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
+                                        created files by default.'
                                       format: int32
                                       type: integer
                                     items:
@@ -5334,32 +4037,17 @@ spec:
                                           mode:
                                             description: 'Optional: mode bits used
                                               to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
+                                              be an octal value between 0000 and 07'
                                             format: int32
                                             type: integer
                                           path:
                                             description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
+                                              path name of the file to be created.'
                                             type: string
                                           resourceFieldRef:
                                             description: 'Selects a resource of the
                                               container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
+                                              requests (limits.cpu, limits.'
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -5387,136 +4075,58 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'EmptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: EmptyDir represents a temporary directory
+                                    that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: 'What type of storage medium should
-                                        back this directory. The default is "" which
-                                        means to use the node''s default medium. Must
-                                        be an empty string (default) or Memory. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: What type of storage medium should
+                                        back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'Total amount of local storage
-                                        required for this EmptyDir volume. The size
-                                        limit is also applicable for memory medium.
-                                        The maximum usage on memory medium EmptyDir
-                                        would be the minimum value between the SizeLimit
-                                        specified here and the sum of memory limits
-                                        of all containers in a pod. The default is
-                                        nil which means that the limit is undefined.
-                                        More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                      description: Total amount of local storage required
+                                        for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "Ephemeral represents a volume that
+                                  description: Ephemeral represents a volume that
                                     is handled by a cluster storage driver (Alpha
-                                    feature). The volume's lifecycle is tied to the
-                                    pod that defines it - it will be created before
-                                    the pod starts, and deleted when the pod is removed.
-                                    \n Use this if: a) the volume is only needed while
-                                    the pod runs, b) features of normal volumes like
-                                    restoring from snapshot or capacity    tracking
-                                    are needed, c) the storage driver is specified
-                                    through a storage class, and d) the storage driver
-                                    supports dynamic volume provisioning through    a
-                                    PersistentVolumeClaim (see EphemeralVolumeSource
-                                    for more    information on the connection between
-                                    this volume type    and PersistentVolumeClaim).
-                                    \n Use PersistentVolumeClaim or one of the vendor-specific
-                                    APIs for volumes that persist for longer than
-                                    the lifecycle of an individual pod. \n Use CSI
-                                    for light-weight local ephemeral volumes if the
-                                    CSI driver is meant to be used that way - see
-                                    the documentation of the driver for more information.
-                                    \n A pod can use both types of ephemeral volumes
-                                    and persistent volumes at the same time."
+                                    feature).
                                   properties:
                                     readOnly:
                                       description: Specifies a read-only configuration
                                         for the volume. Defaults to false (read/write).
                                       type: boolean
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
+                                      description: Will be used to create a stand-alone
+                                        PVC to provision the volume.
                                       properties:
                                         metadata:
                                           description: May contain labels and annotations
                                             that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
+                                            creating it.
                                           type: object
                                         spec:
                                           description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
                                               description: 'AccessModes contains the
                                                 desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                have. More info: https://kubernetes.'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
                                               description: 'This field can be used
                                                 to specify either: * An existing VolumeSnapshot
-                                                object (snapshot.storage.k8s.io/VolumeSnapshot
-                                                - Beta) * An existing PVC (PersistentVolumeClaim)
-                                                * An existing custom resource/object
-                                                that implements data population (Alpha)
-                                                In order to use VolumeSnapshot object
-                                                types, the appropriate feature gate
-                                                must be enabled (VolumeSnapshotDataSource
-                                                or AnyVolumeDataSource) If the provisioner
-                                                or an external controller can support
-                                                the specified data source, it will
-                                                create a new volume based on the contents
-                                                of the specified data source. If the
-                                                specified data source is not supported,
-                                                the volume will not be created and
-                                                the failure will be reported as an
-                                                event. In the future, we plan to support
-                                                more data source types and the behavior
-                                                of the provisioner may change.'
+                                                object (snapshot.storage.k8s.'
                                               properties:
                                                 apiGroup:
                                                   description: APIGroup is the group
                                                     for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
                                                   description: Kind is the type of
@@ -5533,7 +4143,7 @@ spec:
                                             resources:
                                               description: 'Resources represents the
                                                 minimum resources the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                have. More info: https://kubernetes.'
                                               properties:
                                                 limits:
                                                   additionalProperties:
@@ -5544,7 +4154,7 @@ spec:
                                                     x-kubernetes-int-or-string: true
                                                   description: 'Limits describes the
                                                     maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                    allowed. More info: https://kubernetes.'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -5553,14 +4163,9 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
+                                                  description: Requests describes
                                                     the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                    resources required.
                                                   type: object
                                               type: object
                                             selector:
@@ -5575,8 +4180,7 @@ spec:
                                                     description: A label selector
                                                       requirement is a selector that
                                                       contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                      an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -5586,21 +4190,11 @@ spec:
                                                       operator:
                                                         description: operator represents
                                                           a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                          a set of values.
                                                         type: string
                                                       values:
                                                         description: values is an
                                                           array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -5613,26 +4207,18 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                             storageClassName:
                                               description: 'Name of the StorageClass
                                                 required by the claim. More info:
-                                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                https://kubernetes.'
                                               type: string
                                             volumeMode:
                                               description: volumeMode defines what
                                                 type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
+                                                claim.
                                               type: string
                                             volumeName:
                                               description: VolumeName is the binding
@@ -5647,24 +4233,19 @@ spec:
                                 fc:
                                   description: FC represents a Fibre Channel resource
                                     that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
+                                    then exposed
                                   properties:
                                     fsType:
-                                      description: 'Filesystem type to mount. Must
+                                      description: Filesystem type to mount. Must
                                         be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                        operating system. Ex.
                                       type: string
                                     lun:
                                       description: 'Optional: FC target lun number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'Optional: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.'
+                                      description: 'Optional: Defaults to false (read/write).'
                                       type: boolean
                                     targetWWNs:
                                       description: 'Optional: FC target worldwide
@@ -5675,8 +4256,7 @@ spec:
                                     wwids:
                                       description: 'Optional: FC volume world wide
                                         identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
+                                        of targetWWNs and lun'
                                       items:
                                         type: string
                                       type: array
@@ -5684,7 +4264,7 @@ spec:
                                 flexVolume:
                                   description: FlexVolume represents a generic volume
                                     resource that is provisioned/attached using an
-                                    exec based plugin.
+                                    exec based plu
                                   properties:
                                     driver:
                                       description: Driver is the name of the driver
@@ -5693,9 +4273,7 @@ spec:
                                     fsType:
                                       description: Filesystem type to mount. Must
                                         be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        The default filesystem depends on FlexVolume
-                                        script.
+                                        operating system. Ex.
                                       type: string
                                     options:
                                       additionalProperties:
@@ -5704,24 +4282,16 @@ spec:
                                         if any.'
                                       type: object
                                     readOnly:
-                                      description: 'Optional: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.'
+                                      description: 'Optional: Defaults to false (read/write).'
                                       type: boolean
                                     secretRef:
                                       description: 'Optional: SecretRef is reference
                                         to the secret object containing sensitive
-                                        information to pass to the plugin scripts.
-                                        This may be empty if no secret object is specified.
-                                        If the secret object contains more than one
-                                        secret, all secrets are passed to the plugin
-                                        scripts.'
+                                        information to pass to th'
                                       properties:
                                         name:
                                           description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                   required:
@@ -5729,13 +4299,12 @@ spec:
                                   type: object
                                 flocker:
                                   description: Flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
+                                    attached to a kubelet's host machine.
                                   properties:
                                     datasetName:
                                       description: Name of the dataset stored as metadata
                                         -> name on the dataset for Flocker should
-                                        be considered as deprecated
+                                        be considered as de
                                       type: string
                                     datasetUUID:
                                       description: UUID of the dataset. This is unique
@@ -5743,40 +4312,26 @@ spec:
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'GCEPersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: GCEPersistentDisk represents a GCE
+                                    Disk resource that is attached to a kubelet's
+                                    host machine and th
                                   properties:
                                     fsType:
-                                      description: 'Filesystem type of the volume
-                                        that you want to mount. Tip: Ensure that the
-                                        filesystem type is supported by the host operating
-                                        system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                        inferred to be "ext4" if unspecified. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                      description: Filesystem type of the volume that
+                                        you want to mount.
                                       type: string
                                     partition:
-                                      description: 'The partition in the volume that
-                                        you want to mount. If omitted, the default
-                                        is to mount by volume name. Examples: For
-                                        volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      description: The partition in the volume that
+                                        you want to mount.
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'Unique name of the PD resource
+                                      description: Unique name of the PD resource
                                         in GCE. Used to identify the disk in GCE.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'ReadOnly here will force the ReadOnly
+                                      description: ReadOnly here will force the ReadOnly
                                         setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
@@ -5784,18 +4339,11 @@ spec:
                                 gitRepo:
                                   description: 'GitRepo represents a git repository
                                     at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
+                                    is deprecated.'
                                   properties:
                                     directory:
                                       description: Target directory name. Must not
-                                        contain or start with '..'.  If '.' is supplied,
-                                        the volume directory will be the git repository.  Otherwise,
-                                        if specified, the volume will contain the
-                                        git repository in the subdirectory with the
-                                        given name.
+                                        contain or start with '..'.  If '.
                                       type: string
                                     repository:
                                       description: Repository URL
@@ -5807,55 +4355,45 @@ spec:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'Glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                  description: Glusterfs represents a Glusterfs mount
+                                    on the host that shares a pod's lifetime.
                                   properties:
                                     endpoints:
                                       description: 'EndpointsName is the endpoint
                                         name that details Glusterfs topology. More
-                                        info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        info: https://examples.k8s.'
                                       type: string
                                     path:
                                       description: 'Path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.'
                                       type: string
                                     readOnly:
-                                      description: 'ReadOnly here will force the Glusterfs
+                                      description: ReadOnly here will force the Glusterfs
                                         volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'HostPath represents a pre-existing
+                                  description: HostPath represents a pre-existing
                                     file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
+                                    directly exposed to
                                   properties:
                                     path:
-                                      description: 'Path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: Path of the directory on the host.
                                       type: string
                                     type:
                                       description: 'Type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'ISCSI represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                  description: ISCSI represents an ISCSI Disk resource
+                                    that is attached to a kubelet's host machine and
+                                    then expose
                                   properties:
                                     chapAuthDiscovery:
                                       description: whether support iSCSI Discovery
@@ -5866,21 +4404,11 @@ spec:
                                         authentication
                                       type: boolean
                                     fsType:
-                                      description: 'Filesystem type of the volume
-                                        that you want to mount. Tip: Ensure that the
-                                        filesystem type is supported by the host operating
-                                        system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                        inferred to be "ext4" if unspecified. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                      description: Filesystem type of the volume that
+                                        you want to mount.
                                       type: string
                                     initiatorName:
-                                      description: Custom iSCSI Initiator Name. If
-                                        initiatorName is specified with iscsiInterface
-                                        simultaneously, new iSCSI interface <target
-                                        portal>:<volume name> will be created for
-                                        the connection.
+                                      description: Custom iSCSI Initiator Name.
                                       type: string
                                     iqn:
                                       description: Target iSCSI Qualified Name.
@@ -5895,10 +4423,7 @@ spec:
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: iSCSI Target Portal List. The portal
-                                        is either an IP or ip_addr:port if the port
-                                        is other than default (typically TCP ports
-                                        860 and 3260).
+                                      description: iSCSI Target Portal List.
                                       items:
                                         type: string
                                       type: array
@@ -5912,16 +4437,11 @@ spec:
                                       properties:
                                         name:
                                           description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     targetPortal:
-                                      description: iSCSI Target Portal. The Portal
-                                        is either an IP or ip_addr:port if the port
-                                        is other than default (typically TCP ports
-                                        860 and 3260).
+                                      description: iSCSI Target Portal.
                                       type: string
                                   required:
                                   - iqn
@@ -5930,39 +4450,39 @@ spec:
                                   type: object
                                 name:
                                   description: 'Volume''s name. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    and unique within the pod. More info: https://kubernetes.'
                                   type: string
                                 nfs:
                                   description: 'NFS represents an NFS mount on the
                                     host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    https://kubernetes.'
                                   properties:
                                     path:
                                       description: 'Path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        server. More info: https://kubernetes.'
                                       type: string
                                     readOnly:
-                                      description: 'ReadOnly here will force the NFS
+                                      description: ReadOnly here will force the NFS
                                         export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        Defaults to false.
                                       type: boolean
                                     server:
                                       description: 'Server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        of the NFS server. More info: https://kubernetes.'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'PersistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: PersistentVolumeClaimVolumeSource represents
+                                    a reference to a PersistentVolumeClaim in the
+                                    same name
                                   properties:
                                     claimName:
-                                      description: 'ClaimName is the name of a PersistentVolumeClaim
+                                      description: ClaimName is the name of a PersistentVolumeClaim
                                         in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        volume.
                                       type: string
                                     readOnly:
                                       description: Will force the ReadOnly setting
@@ -5972,15 +4492,14 @@ spec:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: PhotonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
+                                  description: 'PhotonPersistentDisk represents a
+                                    PhotonController persistent disk attached and
+                                    mounted on kubelets '
                                   properties:
                                     fsType:
                                       description: Filesystem type to mount. Must
                                         be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
+                                        operating system. Ex.
                                       type: string
                                     pdID:
                                       description: ID that identifies Photon Controller
@@ -5996,9 +4515,7 @@ spec:
                                     fsType:
                                       description: FSType represents the filesystem
                                         type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
+                                        by the host opera
                                       type: string
                                     readOnly:
                                       description: Defaults to false (read/write).
@@ -6018,15 +4535,7 @@ spec:
                                   properties:
                                     defaultMode:
                                       description: Mode bits used to set permissions
-                                        on created files by default. Must be an octal
-                                        value between 0000 and 0777 or a decimal value
-                                        between 0 and 511. YAML accepts both octal
-                                        and decimal values, JSON requires decimal
-                                        values for mode bits. Directories within the
-                                        path are not affected by this setting. This
-                                        might be in conflict with other options that
-                                        affect the file mode, like fsGroup, and the
-                                        result can be other mode bits set.
+                                        on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
@@ -6040,21 +4549,10 @@ spec:
                                               data to project
                                             properties:
                                               items:
-                                                description: If unspecified, each
+                                                description: 'If unspecified, each
                                                   key-value pair in the Data field
                                                   of the referenced ConfigMap will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
+                                                  be projected '
                                                 items:
                                                   description: Maps a string key to
                                                     a path within a volume.
@@ -6065,28 +4563,14 @@ spec:
                                                     mode:
                                                       description: 'Optional: mode
                                                         bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
+                                                        on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
                                                       description: The relative path
                                                         of the file to map the key
                                                         to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
+                                                        path.
                                                       type: string
                                                   required:
                                                   - key
@@ -6095,9 +4579,7 @@ spec:
                                                 type: array
                                               name:
                                                 description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -6140,37 +4622,19 @@ spec:
                                                       description: 'Optional: mode
                                                         bits used to set permissions
                                                         on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
+                                                        value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
                                                       description: 'Required: Path
                                                         is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
+                                                        of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
                                                       description: 'Selects a resource
                                                         of the container: only resources
                                                         limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
+                                                        limits.'
                                                       properties:
                                                         containerName:
                                                           description: 'Container
@@ -6207,18 +4671,7 @@ spec:
                                                 description: If unspecified, each
                                                   key-value pair in the Data field
                                                   of the referenced Secret will be
-                                                  projected into the volume as a file
-                                                  whose name is the key and content
-                                                  is the value. If specified, the
-                                                  listed keys will be projected into
-                                                  the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
+                                                  projected int
                                                 items:
                                                   description: Maps a string key to
                                                     a path within a volume.
@@ -6229,28 +4682,14 @@ spec:
                                                     mode:
                                                       description: 'Optional: mode
                                                         bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
+                                                        on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
                                                       description: The relative path
                                                         of the file to map the key
                                                         to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
+                                                        path.
                                                       type: string
                                                   required:
                                                   - key
@@ -6259,9 +4698,7 @@ spec:
                                                 type: array
                                               name:
                                                 description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -6274,27 +4711,12 @@ spec:
                                             properties:
                                               audience:
                                                 description: Audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
+                                                  audience of the token.
                                                 type: string
                                               expirationSeconds:
                                                 description: ExpirationSeconds is
                                                   the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
+                                                  of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
@@ -6321,20 +4743,16 @@ spec:
                                     readOnly:
                                       description: ReadOnly here will force the Quobyte
                                         volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
                                       description: Registry represents a single or
                                         multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
+                                        as a string as host:por
                                       type: string
                                     tenant:
                                       description: Tenant owning the given Quobyte
                                         volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
+                                        provisioned Quobyte volu
                                       type: string
                                     user:
                                       description: User to map volume access to Defaults
@@ -6349,59 +4767,48 @@ spec:
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'RBD represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                  description: RBD represents a Rados Block Device
+                                    mount on the host that shares a pod's lifetime.
                                   properties:
                                     fsType:
-                                      description: 'Filesystem type of the volume
-                                        that you want to mount. Tip: Ensure that the
-                                        filesystem type is supported by the host operating
-                                        system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                        inferred to be "ext4" if unspecified. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                      description: Filesystem type of the volume that
+                                        you want to mount.
                                       type: string
                                     image:
                                       description: 'The rados image name. More info:
                                         https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'Keyring is the path to key ring
+                                      description: Keyring is the path to key ring
                                         for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
                                       description: 'A collection of Ceph monitors.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        More info: https://examples.k8s.io/volumes/rbd/README.'
                                       items:
                                         type: string
                                       type: array
                                     pool:
                                       description: 'The rados pool name. Default is
-                                        rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        rbd. More info: https://examples.k8s.io/volumes/rbd/README.'
                                       type: string
                                     readOnly:
-                                      description: 'ReadOnly here will force the ReadOnly
+                                      description: ReadOnly here will force the ReadOnly
                                         setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'SecretRef is name of the authentication
+                                      description: SecretRef is name of the authentication
                                         secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        keyring.
                                       properties:
                                         name:
                                           description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     user:
                                       description: 'The rados user name. Default is
-                                        admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        admin. More info: https://examples.k8s.io/volumes/rbd/README.'
                                       type: string
                                   required:
                                   - image
@@ -6414,8 +4821,7 @@ spec:
                                     fsType:
                                       description: Filesystem type to mount. Must
                                         be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Default is "xfs".
+                                        operating system. Ex.
                                       type: string
                                     gateway:
                                       description: The host address of the ScaleIO
@@ -6433,14 +4839,10 @@ spec:
                                     secretRef:
                                       description: SecretRef references to the secret
                                         for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
                                           description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     sslEnabled:
@@ -6450,7 +4852,6 @@ spec:
                                     storageMode:
                                       description: Indicates whether the storage for
                                         a volume should be ThickProvisioned or ThinProvisioned.
-                                        Default is ThinProvisioned.
                                       type: string
                                     storagePool:
                                       description: The ScaleIO Storage Pool associated
@@ -6463,7 +4864,7 @@ spec:
                                     volumeName:
                                       description: The name of a volume already created
                                         in the ScaleIO system that is associated with
-                                        this volume source.
+                                        this volume sourc
                                       type: string
                                   required:
                                   - gateway
@@ -6472,34 +4873,17 @@ spec:
                                   type: object
                                 secret:
                                   description: 'Secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
                                       description: 'Optional: mode bits used to set
-                                        permissions on created files by default. Must
-                                        be an octal value between 0000 and 0777 or
-                                        a decimal value between 0 and 511. YAML accepts
-                                        both octal and decimal values, JSON requires
-                                        decimal values for mode bits. Defaults to
-                                        0644. Directories within the path are not
-                                        affected by this setting. This might be in
-                                        conflict with other options that affect the
-                                        file mode, like fsGroup, and the result can
-                                        be other mode bits set.'
+                                        permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
                                       description: If unspecified, each key-value
                                         pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
+                                        will be projected int
                                       items:
                                         description: Maps a string key to a path within
                                           a volume.
@@ -6509,25 +4893,13 @@ spec:
                                             type: string
                                           mode:
                                             description: 'Optional: mode bits used
-                                              to set permissions on this file. Must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
+                                              to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
                                             description: The relative path of the
                                               file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
+                                              absolute path.
                                             type: string
                                         required:
                                         - key
@@ -6540,7 +4912,7 @@ spec:
                                       type: boolean
                                     secretName:
                                       description: 'Name of the secret in the pod''s
-                                        namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                                 storageos:
@@ -6550,8 +4922,7 @@ spec:
                                     fsType:
                                       description: Filesystem type to mount. Must
                                         be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
+                                        operating system. Ex.
                                       type: string
                                     readOnly:
                                       description: Defaults to false (read/write).
@@ -6560,32 +4931,20 @@ spec:
                                       type: boolean
                                     secretRef:
                                       description: SecretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
+                                        to use for obtaining the StorageOS API credentials.
                                       properties:
                                         name:
                                           description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     volumeName:
                                       description: VolumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
+                                        name of the StorageOS volume.
                                       type: string
                                     volumeNamespace:
                                       description: VolumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
+                                        of the volume within StorageOS.
                                       type: string
                                   type: object
                                 vsphereVolume:
@@ -6595,8 +4954,7 @@ spec:
                                     fsType:
                                       description: Filesystem type to mount. Must
                                         be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
+                                        operating system. Ex.
                                       type: string
                                     storagePolicyID:
                                       description: Storage Policy Based Management
@@ -6627,9 +4985,7 @@ spec:
                 type: object
               rayVersion:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
-                  RayVersion is the version of ray core. Both Head, Worker and Autoscaler
-                  will use this ray version.'
+                  Important: Run "make" to regenerate code af'
                 type: string
               workerNodeSpec:
                 description: WorkerNodeSpec  the specs for the worker node
@@ -6665,18 +5021,16 @@ spec:
                       description: Ray node group pod template
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: 'Standard object''s metadata. More info: https://git.k8s.'
                           type: object
                         spec:
                           description: 'Specification of the desired behavior of the
-                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                            pod. More info: https://git.k8s.'
                           properties:
                             activeDeadlineSeconds:
                               description: Optional duration in seconds the pod may
                                 be active on the node relative to StartTime before
-                                the system will actively try to mark it failed and
-                                kill associated containers. Value must be a positive
-                                integer.
+                                the syst
                               format: int64
                               type: integer
                             affinity:
@@ -6687,26 +5041,13 @@ spec:
                                     rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
+                                      description: 'The scheduler will prefer to schedule
                                         pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        specified '
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                          0 (i.e. it's a no-op).
                                         properties:
                                           preference:
                                             description: A node selector term, associated
@@ -6716,10 +5057,9 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
+                                                  description: 'A node selector requirement
                                                     is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                    a key, and an operator that relates '
                                                   properties:
                                                     key:
                                                       description: The label key that
@@ -6728,23 +5068,12 @@ spec:
                                                     operator:
                                                       description: Represents a key's
                                                         relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
                                                       type: string
                                                     values:
                                                       description: An array of string
                                                         values. If the operator is
                                                         In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                        must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -6757,10 +5086,9 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
+                                                  description: 'A node selector requirement
                                                     is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                    a key, and an operator that relates '
                                                   properties:
                                                     key:
                                                       description: The label key that
@@ -6769,23 +5097,12 @@ spec:
                                                     operator:
                                                       description: Represents a key's
                                                         relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
                                                       type: string
                                                     values:
                                                       description: An array of string
                                                         values. If the operator is
                                                         In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                        must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -6809,12 +5126,7 @@ spec:
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       description: If the affinity requirements specified
                                         by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                        the pod will no
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -6822,17 +5134,15 @@ spec:
                                           items:
                                             description: A null or empty node selector
                                               term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                              of them are ANDed.
                                             properties:
                                               matchExpressions:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
+                                                  description: 'A node selector requirement
                                                     is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                    a key, and an operator that relates '
                                                   properties:
                                                     key:
                                                       description: The label key that
@@ -6841,23 +5151,12 @@ spec:
                                                     operator:
                                                       description: Represents a key's
                                                         relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
                                                       type: string
                                                     values:
                                                       description: An array of string
                                                         values. If the operator is
                                                         In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                        must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -6870,10 +5169,9 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
+                                                  description: 'A node selector requirement
                                                     is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                    a key, and an operator that relates '
                                                   properties:
                                                     key:
                                                       description: The label key that
@@ -6882,23 +5180,12 @@ spec:
                                                     operator:
                                                       description: Represents a key's
                                                         relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
                                                       type: string
                                                     values:
                                                       description: An array of string
                                                         values. If the operator is
                                                         In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                        must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -6916,27 +5203,16 @@ spec:
                                 podAffinity:
                                   description: Describes pod affinity scheduling rules
                                     (e.g. co-locate this pod in the same node, zone,
-                                    etc. as some other pod(s)).
+                                    etc.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
+                                      description: 'The scheduler will prefer to schedule
                                         pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                        specified '
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
-                                          per-node to find the most preferred node(s)
+                                          per-node to find the most
                                         properties:
                                           podAffinityTerm:
                                             description: Required. A pod affinity
@@ -6957,7 +5233,6 @@ spec:
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
-                                                        the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -6967,21 +5242,11 @@ spec:
                                                         operator:
                                                           description: operator represents
                                                             a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                            a set of values.
                                                           type: string
                                                         values:
                                                           description: values is an
                                                             array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -6994,36 +5259,21 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                      map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies
+                                                description: 'namespaces specifies
                                                   which namespaces the labelSelector
                                                   applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  or empty '
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
                                                 description: This pod should be co-located
                                                   (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  with the pods matching th
                                                 type: string
                                             required:
                                             - topologyKey
@@ -7042,25 +5292,11 @@ spec:
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       description: If the affinity requirements specified
                                         by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                        the pod will no
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          to the given namespace(s)) t
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -7074,7 +5310,6 @@ spec:
                                                   description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
-                                                    the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -7084,20 +5319,11 @@ spec:
                                                     operator:
                                                       description: operator represents
                                                         a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                        set of values.
                                                       type: string
                                                     values:
                                                       description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
+                                                        of string values.
                                                       items:
                                                         type: string
                                                       type: array
@@ -7110,33 +5336,20 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                  of {key,value} pairs.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which
+                                            description: 'namespaces specifies which
                                               namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                              to (matches against); null or empty '
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
                                             description: This pod should be co-located
                                               (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              with the pods matching th
                                             type: string
                                         required:
                                         - topologyKey
@@ -7145,29 +5358,16 @@ spec:
                                   type: object
                                 podAntiAffinity:
                                   description: Describes pod anti-affinity scheduling
-                                    rules (e.g. avoid putting this pod in the same
-                                    node, zone, etc. as some other pod(s)).
+                                    rules (e.g.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
                                       description: The scheduler will prefer to schedule
                                         pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        expressions speci
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
-                                          per-node to find the most preferred node(s)
+                                          per-node to find the most
                                         properties:
                                           podAffinityTerm:
                                             description: Required. A pod affinity
@@ -7188,7 +5388,6 @@ spec:
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
-                                                        the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -7198,21 +5397,11 @@ spec:
                                                         operator:
                                                           description: operator represents
                                                             a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                            a set of values.
                                                           type: string
                                                         values:
                                                           description: values is an
                                                             array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -7225,36 +5414,21 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                      map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies
+                                                description: 'namespaces specifies
                                                   which namespaces the labelSelector
                                                   applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  or empty '
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
                                                 description: This pod should be co-located
                                                   (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  with the pods matching th
                                                 type: string
                                             required:
                                             - topologyKey
@@ -7273,25 +5447,11 @@ spec:
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       description: If the anti-affinity requirements
                                         specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                        time, the pod wi
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          to the given namespace(s)) t
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -7305,7 +5465,6 @@ spec:
                                                   description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
-                                                    the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -7315,20 +5474,11 @@ spec:
                                                     operator:
                                                       description: operator represents
                                                         a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                        set of values.
                                                       type: string
                                                     values:
                                                       description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
+                                                        of string values.
                                                       items:
                                                         type: string
                                                       type: array
@@ -7341,33 +5491,20 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                  of {key,value} pairs.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which
+                                            description: 'namespaces specifies which
                                               namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                              to (matches against); null or empty '
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
                                             description: This pod should be co-located
                                               (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              with the pods matching th
                                             type: string
                                         required:
                                         - topologyKey
@@ -7378,43 +5515,24 @@ spec:
                             automountServiceAccountToken:
                               description: AutomountServiceAccountToken indicates
                                 whether a service account token should be automatically
-                                mounted.
+                                mount
                               type: boolean
                             containers:
                               description: List of containers belonging to the pod.
-                                Containers cannot currently be added or removed. There
-                                must be at least one container in a Pod. Cannot be
-                                updated.
+                                Containers cannot currently be added or removed.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: Arguments to the entrypoint. The
+                                      docker image's CMD is used if this is not provided.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: Entrypoint array. Not executed within
+                                      a shell.
                                     items:
                                       type: string
                                     type: array
@@ -7430,17 +5548,9 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previous defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            environment variables in the
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -7455,9 +5565,7 @@ spec:
                                                   type: string
                                                 name:
                                                   description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -7469,9 +5577,7 @@ spec:
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                                `metadata.'
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -7488,10 +5594,7 @@ spec:
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                                and requests (limits.cpu, limits.'
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -7525,9 +5628,7 @@ spec:
                                                   type: string
                                                 name:
                                                   description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -7543,14 +5644,7 @@ spec:
                                     type: array
                                   envFrom:
                                     description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      variables in the container.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -7560,9 +5654,7 @@ spec:
                                           properties:
                                             name:
                                               description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -7579,9 +5671,7 @@ spec:
                                           properties:
                                             name:
                                               description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -7591,30 +5681,20 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: 'Docker image name. More info: https://kubernetes.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: Image pull policy. One of Always,
+                                      Never, IfNotPresent.
                                     type: string
                                   lifecycle:
                                     description: Actions that the management system
                                       should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                      events.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: PostStart is called immediately
+                                          after a container is created.
                                         properties:
                                           exec:
                                             description: One and only one of the following
@@ -7622,17 +5702,9 @@ spec:
                                               the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
+                                                description: 'Command is the command
                                                   line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
@@ -7643,9 +5715,7 @@ spec:
                                             properties:
                                               host:
                                                 description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -7680,7 +5750,7 @@ spec:
                                                 description: Name or number of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 description: Scheme to use for connecting
@@ -7690,10 +5760,8 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -7707,29 +5775,16 @@ spec:
                                                 description: Number or name of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          an API request or management e
                                         properties:
                                           exec:
                                             description: One and only one of the following
@@ -7737,17 +5792,9 @@ spec:
                                               the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
+                                                description: 'Command is the command
                                                   line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
@@ -7758,9 +5805,7 @@ spec:
                                             properties:
                                               host:
                                                 description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -7795,7 +5840,7 @@ spec:
                                                 description: Name or number of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 description: Scheme to use for connecting
@@ -7805,10 +5850,8 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -7822,7 +5865,7 @@ spec:
                                                 description: Number or name of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -7830,9 +5873,8 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: One and only one of the following
@@ -7840,17 +5882,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -7858,8 +5892,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -7868,8 +5901,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -7899,8 +5931,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -7910,9 +5941,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -7924,16 +5954,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -7945,34 +5971,25 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
                                     description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                      a DNS_LABEL.
                                     type: string
                                   ports:
                                     description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                      container.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -7990,17 +6007,13 @@ spec:
                                         hostPort:
                                           description: Number of port to expose on
                                             the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
-                                            Most containers do not need this.
+                                            valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         name:
                                           description: If specified, this must be
                                             an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                            pod.
                                           type: string
                                         protocol:
                                           default: TCP
@@ -8016,10 +6029,8 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: Periodic probe of container service
+                                      readiness.
                                     properties:
                                       exec:
                                         description: One and only one of the following
@@ -8027,17 +6038,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -8045,8 +6048,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -8055,8 +6057,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -8086,8 +6087,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -8097,9 +6097,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -8111,16 +6110,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -8132,22 +6127,21 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -8158,7 +6152,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -8167,33 +6161,22 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: Requests describes the minimum
+                                          amount of compute resources required.
                                         type: object
                                     type: object
                                   securityContext:
                                     description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      run with. More info: https://kubernetes.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          than its parent process
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime.
+                                          when running containers.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -8212,17 +6195,10 @@ spec:
                                         type: object
                                       privileged:
                                         description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
+                                          proc mount to use for the containers.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -8231,42 +6207,21 @@ spec:
                                       runAsGroup:
                                         description: The GID to run the entrypoint
                                           of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          if unset.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
                                         description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          must run as a non-root user.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          of the container process.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
                                         description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          to the container.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -8287,47 +6242,27 @@ spec:
                                         type: object
                                       seccompProfile:
                                         description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options.
+                                          this container.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
                                               a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must only be set if type is
-                                              "Localhost".
+                                              should be used.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
+                                            description: type indicates which kind
                                               of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
                                         description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          applied to all containers.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                              the GMSA admission webhook (https://github.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -8337,28 +6272,13 @@ spec:
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                              process.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized.
                                     properties:
                                       exec:
                                         description: One and only one of the following
@@ -8366,17 +6286,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -8384,8 +6296,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -8394,8 +6305,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -8425,8 +6335,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -8436,9 +6345,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -8450,16 +6358,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -8471,68 +6375,40 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
                                     description: Whether this container should allocate
                                       a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
                                     type: boolean
                                   stdinOnce:
                                     description: Whether the container runtime should
                                       close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      by a single at
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
                                       to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      will be written is mou'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
+                                      should be populated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
                                       a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                      true.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -8570,9 +6446,7 @@ spec:
                                         mountPropagation:
                                           description: mountPropagation determines
                                             how mounts are propagated from the host
-                                            to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            to container and the other way a
                                           type: string
                                         name:
                                           description: This must match the Name of
@@ -8586,16 +6460,12 @@ spec:
                                         subPath:
                                           description: Path within the volume from
                                             which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                            mounted.
                                           type: string
                                         subPathExpr:
                                           description: Expanded path within the volume
                                             from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                            be mounted.
                                           type: string
                                       required:
                                       - mountPath
@@ -8603,10 +6473,7 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: Container's working directory.
                                     type: string
                                 required:
                                 - name
@@ -8614,23 +6481,16 @@ spec:
                               type: array
                             dnsConfig:
                               description: Specifies the DNS parameters of a pod.
-                                Parameters specified here will be merged to the generated
-                                DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
                                   description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
                                   description: A list of DNS resolver options. This
                                     will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
+                                    from DNSPolicy.
                                   items:
                                     description: PodDNSConfigOption defines DNS resolver
                                       options of a pod.
@@ -8644,80 +6504,36 @@ spec:
                                   type: array
                                 searches:
                                   description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
+                                    lookup.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
                               description: Set DNS policy for the pod. Defaults to
-                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                                "ClusterFirst".
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information
-                                about services should be injected into pod''s environment
-                                variables, matching the syntax of Docker links. Optional:
-                                Defaults to true.'
+                              description: EnableServiceLinks indicates whether information
+                                about services should be injected into pod's enviro
                               type: boolean
                             ephemeralContainers:
                               description: List of ephemeral containers run in this
-                                pod. Ephemeral containers may be run in an existing
-                                pod to perform user-initiated actions such as debugging.
-                                This list cannot be specified when creating a pod,
-                                and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
-                                This field is alpha-level and is only honored by servers
-                                that enable the EphemeralContainers feature.
+                                pod.
                               items:
                                 description: An EphemeralContainer is a container
                                   that may be added temporarily to an existing pod
-                                  for user-initiated activities such as debugging.
-                                  Ephemeral containers have no resource or scheduling
-                                  guarantees, and they will not be restarted when
-                                  they exit or when a pod is removed or restarted.
-                                  If an ephemeral container causes a pod to exceed
-                                  its resource allocation, the pod may be evicted.
-                                  Ephemeral containers may not be added by directly
-                                  updating the pod spec. They must be added via the
-                                  pod's ephemeralcontainers subresource, and they
-                                  will appear in the pod spec once added. This is
-                                  an alpha feature enabled by the EphemeralContainers
-                                  feature flag.
+                                  for user-initi
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: Arguments to the entrypoint. The
+                                      docker image's CMD is used if this is not provided.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: Entrypoint array. Not executed within
+                                      a shell.
                                     items:
                                       type: string
                                     type: array
@@ -8733,17 +6549,9 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previous defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            environment variables in the
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -8758,9 +6566,7 @@ spec:
                                                   type: string
                                                 name:
                                                   description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -8772,9 +6578,7 @@ spec:
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                                `metadata.'
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -8791,10 +6595,7 @@ spec:
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                                and requests (limits.cpu, limits.'
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -8828,9 +6629,7 @@ spec:
                                                   type: string
                                                 name:
                                                   description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -8846,14 +6645,7 @@ spec:
                                     type: array
                                   envFrom:
                                     description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      variables in the container.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -8863,9 +6655,7 @@ spec:
                                           properties:
                                             name:
                                               description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -8882,9 +6672,7 @@ spec:
                                           properties:
                                             name:
                                               description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -8897,22 +6685,16 @@ spec:
                                     description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: Image pull policy. One of Always,
+                                      Never, IfNotPresent.
                                     type: string
                                   lifecycle:
                                     description: Lifecycle is not allowed for ephemeral
                                       containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: PostStart is called immediately
+                                          after a container is created.
                                         properties:
                                           exec:
                                             description: One and only one of the following
@@ -8920,17 +6702,9 @@ spec:
                                               the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
+                                                description: 'Command is the command
                                                   line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
@@ -8941,9 +6715,7 @@ spec:
                                             properties:
                                               host:
                                                 description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -8978,7 +6750,7 @@ spec:
                                                 description: Name or number of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 description: Scheme to use for connecting
@@ -8988,10 +6760,8 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -9005,29 +6775,16 @@ spec:
                                                 description: Number or name of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          an API request or management e
                                         properties:
                                           exec:
                                             description: One and only one of the following
@@ -9035,17 +6792,9 @@ spec:
                                               the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
+                                                description: 'Command is the command
                                                   line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
@@ -9056,9 +6805,7 @@ spec:
                                             properties:
                                               host:
                                                 description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -9093,7 +6840,7 @@ spec:
                                                 description: Name or number of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 description: Scheme to use for connecting
@@ -9103,10 +6850,8 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -9120,7 +6865,7 @@ spec:
                                                 description: Number or name of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -9137,17 +6882,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -9155,8 +6892,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -9165,8 +6901,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -9196,8 +6931,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -9207,9 +6941,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -9221,16 +6954,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -9242,24 +6971,21 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
                                     description: Name of the ephemeral container specified
-                                      as a DNS_LABEL. This name must be unique among
-                                      all containers, init containers and ephemeral
-                                      containers.
+                                      as a DNS_LABEL.
                                     type: string
                                   ports:
                                     description: Ports are not allowed for ephemeral
@@ -9281,17 +7007,13 @@ spec:
                                         hostPort:
                                           description: Number of port to expose on
                                             the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
-                                            Most containers do not need this.
+                                            valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         name:
                                           description: If specified, this must be
                                             an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                            pod.
                                           type: string
                                         protocol:
                                           default: TCP
@@ -9312,17 +7034,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -9330,8 +7044,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -9340,8 +7053,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -9371,8 +7083,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -9382,9 +7093,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -9396,16 +7106,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -9417,23 +7123,21 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
                                     description: Resources are not allowed for ephemeral
-                                      containers. Ephemeral containers use spare resources
-                                      already allocated to the pod.
+                                      containers.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -9444,7 +7148,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -9453,12 +7157,8 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: Requests describes the minimum
+                                          amount of compute resources required.
                                         type: object
                                     type: object
                                   securityContext:
@@ -9466,19 +7166,13 @@ spec:
                                       ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          than its parent process
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime.
+                                          when running containers.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -9497,17 +7191,10 @@ spec:
                                         type: object
                                       privileged:
                                         description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
+                                          proc mount to use for the containers.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -9516,42 +7203,21 @@ spec:
                                       runAsGroup:
                                         description: The GID to run the entrypoint
                                           of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          if unset.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
                                         description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          must run as a non-root user.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          of the container process.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
                                         description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          to the container.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -9572,47 +7238,27 @@ spec:
                                         type: object
                                       seccompProfile:
                                         description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options.
+                                          this container.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
                                               a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must only be set if type is
-                                              "Localhost".
+                                              should be used.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
+                                            description: type indicates which kind
                                               of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
                                         description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          applied to all containers.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                              the GMSA admission webhook (https://github.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -9622,12 +7268,7 @@ spec:
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                              process.
                                             type: string
                                         type: object
                                     type: object
@@ -9641,17 +7282,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -9659,8 +7292,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -9669,8 +7301,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -9700,8 +7331,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -9711,9 +7341,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -9725,16 +7354,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -9746,77 +7371,44 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
                                     description: Whether this container should allocate
                                       a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
                                     type: boolean
                                   stdinOnce:
                                     description: Whether the container runtime should
                                       close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      by a single at
                                     type: boolean
                                   targetContainerName:
                                     description: If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
-                                      The ephemeral container will be run in the namespaces
-                                      (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container is run in whatever
-                                      namespaces are shared for the pod. Note that
-                                      the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
                                       to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      will be written is mou'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
+                                      should be populated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
                                       a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                      true.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -9854,9 +7446,7 @@ spec:
                                         mountPropagation:
                                           description: mountPropagation determines
                                             how mounts are propagated from the host
-                                            to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            to container and the other way a
                                           type: string
                                         name:
                                           description: This must match the Name of
@@ -9870,16 +7460,12 @@ spec:
                                         subPath:
                                           description: Path within the volume from
                                             which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                            mounted.
                                           type: string
                                         subPathExpr:
                                           description: Expanded path within the volume
                                             from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                            be mounted.
                                           type: string
                                       required:
                                       - mountPath
@@ -9887,24 +7473,20 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: Container's working directory.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts
-                                and IPs that will be injected into the pod's hosts
-                                file if specified. This is only valid for non-hostNetwork
-                                pods.
+                              description: 'HostAliases is an optional list of hosts
+                                and IPs that will be injected into the pod''s hosts
+                                file if '
                               items:
-                                description: HostAlias holds the mapping between IP
-                                  and hostnames that will be injected as an entry
-                                  in the pod's hosts file.
+                                description: 'HostAlias holds the mapping between
+                                  IP and hostnames that will be injected as an entry
+                                  in the pod''s '
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -9922,9 +7504,7 @@ spec:
                               type: boolean
                             hostNetwork:
                               description: Host networking requested for this pod.
-                                Use the host's network namespace. If this option is
-                                set, the ports that will be used must be specified.
-                                Default to false.
+                                Use the host's network namespace.
                               type: boolean
                             hostPID:
                               description: 'Use the host''s pid namespace. Optional:
@@ -9932,77 +7512,39 @@ spec:
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
-                                specified, the pod's hostname will be set to a system-defined
-                                value.
+                                specified, the pod's hostname will be set to a system-defin
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of
+                              description: ImagePullSecrets is an optional list of
                                 references to secrets in the same namespace to use
-                                for pulling any of the images used by this PodSpec.
-                                If specified, these secrets will be passed to individual
-                                puller implementations for them to use. For example,
-                                in the case of docker, only DockerConfig type secrets
-                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                for pulli
                               items:
-                                description: LocalObjectReference contains enough
+                                description: 'LocalObjectReference contains enough
                                   information to let you locate the referenced object
-                                  inside the same namespace.
+                                  inside the '
                                 properties:
                                   name:
                                     description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      https://kubernetes.'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging
-                                to the pod. Init containers are executed in order
-                                prior to containers being started. If any init container
-                                fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers. Init containers may not have
-                                Lifecycle actions, Readiness probes, Liveness probes,
-                                or Startup probes. The resourceRequirements of an
-                                init container are taken into account during scheduling
-                                by finding the highest request/limit for each resource
-                                type, and then using the max of of that value or the
-                                sum of the normal containers. Limits are applied to
-                                init containers in a similar fashion. Init containers
-                                cannot currently be added or removed. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              description: List of initialization containers belonging
+                                to the pod.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: Arguments to the entrypoint. The
+                                      docker image's CMD is used if this is not provided.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: Entrypoint array. Not executed within
+                                      a shell.
                                     items:
                                       type: string
                                     type: array
@@ -10018,17 +7560,9 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previous defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            environment variables in the
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -10043,9 +7577,7 @@ spec:
                                                   type: string
                                                 name:
                                                   description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -10057,9 +7589,7 @@ spec:
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                                `metadata.'
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -10076,10 +7606,7 @@ spec:
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                                and requests (limits.cpu, limits.'
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -10113,9 +7640,7 @@ spec:
                                                   type: string
                                                 name:
                                                   description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -10131,14 +7656,7 @@ spec:
                                     type: array
                                   envFrom:
                                     description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      variables in the container.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -10148,9 +7666,7 @@ spec:
                                           properties:
                                             name:
                                               description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -10167,9 +7683,7 @@ spec:
                                           properties:
                                             name:
                                               description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -10179,30 +7693,20 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: 'Docker image name. More info: https://kubernetes.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: Image pull policy. One of Always,
+                                      Never, IfNotPresent.
                                     type: string
                                   lifecycle:
                                     description: Actions that the management system
                                       should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                      events.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: PostStart is called immediately
+                                          after a container is created.
                                         properties:
                                           exec:
                                             description: One and only one of the following
@@ -10210,17 +7714,9 @@ spec:
                                               the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
+                                                description: 'Command is the command
                                                   line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
@@ -10231,9 +7727,7 @@ spec:
                                             properties:
                                               host:
                                                 description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -10268,7 +7762,7 @@ spec:
                                                 description: Name or number of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 description: Scheme to use for connecting
@@ -10278,10 +7772,8 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -10295,29 +7787,16 @@ spec:
                                                 description: Number or name of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          an API request or management e
                                         properties:
                                           exec:
                                             description: One and only one of the following
@@ -10325,17 +7804,9 @@ spec:
                                               the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
+                                                description: 'Command is the command
                                                   line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
@@ -10346,9 +7817,7 @@ spec:
                                             properties:
                                               host:
                                                 description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -10383,7 +7852,7 @@ spec:
                                                 description: Name or number of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 description: Scheme to use for connecting
@@ -10393,10 +7862,8 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -10410,7 +7877,7 @@ spec:
                                                 description: Number or name of the
                                                   port to access on the container.
                                                   Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -10418,9 +7885,8 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: One and only one of the following
@@ -10428,17 +7894,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -10446,8 +7904,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -10456,8 +7913,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -10487,8 +7943,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -10498,9 +7953,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -10512,16 +7966,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -10533,34 +7983,25 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
                                     description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                      a DNS_LABEL.
                                     type: string
                                   ports:
                                     description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                      container.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -10578,17 +8019,13 @@ spec:
                                         hostPort:
                                           description: Number of port to expose on
                                             the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
-                                            Most containers do not need this.
+                                            valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         name:
                                           description: If specified, this must be
                                             an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                            pod.
                                           type: string
                                         protocol:
                                           default: TCP
@@ -10604,10 +8041,8 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: Periodic probe of container service
+                                      readiness.
                                     properties:
                                       exec:
                                         description: One and only one of the following
@@ -10615,17 +8050,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -10633,8 +8060,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -10643,8 +8069,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -10674,8 +8099,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -10685,9 +8109,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -10699,16 +8122,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -10720,22 +8139,21 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -10746,7 +8164,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -10755,33 +8173,22 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: Requests describes the minimum
+                                          amount of compute resources required.
                                         type: object
                                     type: object
                                   securityContext:
                                     description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      run with. More info: https://kubernetes.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          than its parent process
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime.
+                                          when running containers.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -10800,17 +8207,10 @@ spec:
                                         type: object
                                       privileged:
                                         description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
+                                          proc mount to use for the containers.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -10819,42 +8219,21 @@ spec:
                                       runAsGroup:
                                         description: The GID to run the entrypoint
                                           of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          if unset.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
                                         description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          must run as a non-root user.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          of the container process.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
                                         description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          to the container.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -10875,47 +8254,27 @@ spec:
                                         type: object
                                       seccompProfile:
                                         description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options.
+                                          this container.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
                                               a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must only be set if type is
-                                              "Localhost".
+                                              should be used.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
+                                            description: type indicates which kind
                                               of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
                                         description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          applied to all containers.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                              the GMSA admission webhook (https://github.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -10925,28 +8284,13 @@ spec:
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                              process.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized.
                                     properties:
                                       exec:
                                         description: One and only one of the following
@@ -10954,17 +8298,9 @@ spec:
                                           action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
+                                            description: 'Command is the command line
                                               to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
@@ -10972,8 +8308,7 @@ spec:
                                       failureThreshold:
                                         description: Minimum consecutive failures
                                           for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
@@ -10982,8 +8317,7 @@ spec:
                                         properties:
                                           host:
                                             description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -11013,8 +8347,7 @@ spec:
                                             - type: string
                                             description: Name or number of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
                                             description: Scheme to use for connecting
@@ -11024,9 +8357,8 @@ spec:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
@@ -11038,16 +8370,12 @@ spec:
                                       successThreshold:
                                         description: Minimum consecutive successes
                                           for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -11059,68 +8387,40 @@ spec:
                                             - type: string
                                             description: Number or name of the port
                                               to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
+                                        description: Number of seconds after which
                                           the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
                                     description: Whether this container should allocate
                                       a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
                                     type: boolean
                                   stdinOnce:
                                     description: Whether the container runtime should
                                       close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      by a single at
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
                                       to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      will be written is mou'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
+                                      should be populated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
                                       a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                      true.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -11158,9 +8458,7 @@ spec:
                                         mountPropagation:
                                           description: mountPropagation determines
                                             how mounts are propagated from the host
-                                            to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            to container and the other way a
                                           type: string
                                         name:
                                           description: This must match the Name of
@@ -11174,16 +8472,12 @@ spec:
                                         subPath:
                                           description: Path within the volume from
                                             which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                            mounted.
                                           type: string
                                         subPathExpr:
                                           description: Expanded path within the volume
                                             from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                            be mounted.
                                           type: string
                                       required:
                                       - mountPath
@@ -11191,10 +8485,7 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: Container's working directory.
                                     type: string
                                 required:
                                 - name
@@ -11202,17 +8493,13 @@ spec:
                               type: array
                             nodeName:
                               description: NodeName is a request to schedule this
-                                pod onto a specific node. If it is non-empty, the
-                                scheduler simply schedules this pod onto that node,
-                                assuming that it fits resource requirements.
+                                pod onto a specific node.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must
-                                be true for the pod to fit on a node. Selector which
-                                must match a node''s labels for the pod to be scheduled
-                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: NodeSelector is a selector which must be
+                                true for the pod to fit on a node.
                               type: object
                             overhead:
                               additionalProperties:
@@ -11221,53 +8508,24 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead
+                              description: Overhead represents the resource overhead
                                 associated with running a pod for a given RuntimeClass.
-                                This field will be autopopulated at admission time
-                                by the RuntimeClass admission controller. If the RuntimeClass
-                                admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set. If RuntimeClass is configured
-                                and selected in the PodSpec, Overhead will be set
-                                to the value defined in the corresponding RuntimeClass,
-                                otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                                This field is alpha-level as of Kubernetes v1.16,
-                                and is only honored by servers that enable the PodOverhead
-                                feature.'
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
-                                pods with lower priority. One of Never, PreemptLowerPriority.
-                                Defaults to PreemptLowerPriority if unset. This field
-                                is beta-level, gated by the NonPreemptingPriority
-                                feature-gate.
+                                pods with lower priority.
                               type: string
                             priority:
                               description: The priority value. Various system components
-                                use this field to find the priority of the pod. When
-                                Priority Admission Controller is enabled, it prevents
-                                users from setting this field. The admission controller
-                                populates this field from PriorityClassName. The higher
-                                the value, the higher the priority.
+                                use this field to find the priority of the pod.
                               format: int32
                               type: integer
                             priorityClassName:
                               description: If specified, indicates the pod's priority.
-                                "system-node-critical" and "system-cluster-critical"
-                                are two special keywords which indicate the highest
-                                priorities with the former being the highest priority.
-                                Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will
-                                be evaluated for pod readiness. A pod is ready when
-                                all its containers are ready AND all conditions specified
-                                in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                              description: If specified, all readiness gates will
+                                be evaluated for pod readiness.
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -11281,91 +8539,48 @@ spec:
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within
-                                the pod. One of Always, OnFailure, Never. Default
-                                to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: Restart policy for all containers within
+                                the pod. One of Always, OnFailure, Never.
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
-                                object in the node.k8s.io group, which should be used
-                                to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                                This is a beta feature as of Kubernetes v1.14.'
+                              description: RuntimeClassName refers to a RuntimeClass
+                                object in the node.k8s.
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
-                                by specified scheduler. If not specified, the pod
-                                will be dispatched by default scheduler.
+                                by specified scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: SecurityContext holds pod-level security
+                                attributes and common container settings.
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume."
+                                  description: A special supplemental group that applies
+                                    to all containers in a pod.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
+                                  description: fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
-                                    before being exposed inside Pod. This field will
-                                    only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified defaults to "Always".'
+                                    before being
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
                                     container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
                                   description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                    as a non-root user.
                                   type: boolean
                                 runAsUser:
                                   description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
+                                    container process.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container.
+                                    all containers.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -11391,36 +8606,25 @@ spec:
                                     localhostProfile:
                                       description: localhostProfile indicates a profile
                                         defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must only be set if type is "Localhost".
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: type indicates which kind of seccomp
+                                        profile will be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
+                                  description: 'A list of groups applied to the first
                                     process run in each container, in addition to
-                                    the container's primary GID.  If unspecified,
-                                    no groups will be added to any container.
+                                    the container''s '
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
                                   description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
+                                    used for the pod.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -11438,16 +8642,11 @@ spec:
                                   type: array
                                 windowsOptions:
                                   description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
+                                    to all containers.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                        GMSA admission webhook (https://github.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
@@ -11455,124 +8654,77 @@ spec:
                                       type: string
                                     runAsUserName:
                                       description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                        the entrypoint of the container process.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated
-                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                instead.'
+                              description: DeprecatedServiceAccount is a depreciated
+                                alias for ServiceAccountName.
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the
-                                ServiceAccount to use to run this pod. More info:
-                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: ServiceAccountName is the name of the ServiceAccount
+                                to use to run this pod.
                               type: string
                             setHostnameAsFQDN:
                               description: If true the pod's hostname will be configured
                                 as the pod's FQDN, rather than the leaf name (the
-                                default). In Linux containers, this means setting
-                                the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname). In Windows containers,
-                                this means setting the registry value of hostname
-                                for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                to FQDN. If a pod does not have FQDN, this has no
-                                effect. Default to false.
+                                defa
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
-                                all of the containers in a pod. When this is set containers
-                                will be able to view and signal processes from other
-                                containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                              description: Share a single process namespace between
+                                all of the containers in a pod.
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
-                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                domain>". If not specified, the pod will not have
-                                a domainname at all.
+                                will be "<hostname>.<subdomain>.<pod namespace>.svc.
                               type: string
                             terminationGracePeriodSeconds:
                               description: Optional duration in seconds the pod needs
-                                to terminate gracefully. May be decreased in delete
-                                request. Value must be non-negative integer. The value
-                                zero indicates delete immediately. If this value is
-                                nil, the default grace period will be used instead.
-                                The grace period is the duration in seconds after
-                                the processes running in the pod are sent a termination
-                                signal and the time when the processes are forcibly
-                                halted with a kill signal. Set this value longer than
-                                the expected cleanup time for your process. Defaults
-                                to 30 seconds.
+                                to terminate gracefully.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
                                 description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                  tolerates any taint that matches the triple <key,value,effect
                                 properties:
                                   effect:
                                     description: Effect indicates the taint effect
                                       to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
                                     description: Key is the taint key that the toleration
                                       applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
                                     type: string
                                   operator:
                                     description: Operator represents a key's relationship
                                       to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                      Equal.
                                     type: string
                                   tolerationSeconds:
                                     description: TolerationSeconds represents the
                                       period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                      of effect NoExecute, o
                                     format: int64
                                     type: integer
                                   value:
                                     description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                      matches to.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
                               description: TopologySpreadConstraints describes how
                                 a group of pods ought to spread across topology domains.
-                                Scheduler will schedule pods in a way which abides
-                                by the constraints. All topologySpreadConstraints
-                                are ANDed.
                               items:
                                 description: TopologySpreadConstraint specifies how
                                   to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
                                     description: LabelSelector is used to find matching
-                                      pods. Pods that match this label selector are
-                                      counted to determine the number of pods in their
-                                      corresponding topology domain.
+                                      pods.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -11581,8 +8733,7 @@ spec:
                                         items:
                                           description: A label selector requirement
                                             is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                            key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that
@@ -11590,18 +8741,11 @@ spec:
                                               type: string
                                             operator:
                                               description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                                relationship to a set of values.
                                               type: string
                                             values:
                                               description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                                values.
                                               items:
                                                 type: string
                                               type: array
@@ -11614,63 +8758,21 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                          pairs.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to
-                                      which pods may be unevenly distributed. When
-                                      `whenUnsatisfiable=DoNotSchedule`, it is the
-                                      maximum permitted difference between the number
-                                      of matching pods in the target topology and
-                                      the global minimum. For example, in a 3-zone
-                                      cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 1/1/0: | zone1
-                                      | zone2 | zone3 | |   P   |   P   |       |
-                                      - if MaxSkew is 1, incoming pod can only be
-                                      scheduled to zone3 to become 1/1/1; scheduling
-                                      it onto zone1(zone2) would make the ActualSkew(2-0)
-                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
-                                      is 2, incoming pod can be scheduled onto any
-                                      zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                      it is used to give higher precedence to topologies
-                                      that satisfy it. It''s a required field. Default
-                                      value is 1 and 0 is not allowed.'
+                                    description: MaxSkew describes the degree to which
+                                      pods may be unevenly distributed.
                                     format: int32
                                     type: integer
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
-                                      Nodes that have a label with this key and identical
-                                      values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket",
-                                      and try to put balanced number of pods into
-                                      each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how
-                                      to deal with a pod if it doesn''t satisfy the
-                                      spread constraint. - DoNotSchedule (default)
-                                      tells the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location,   but giving higher precedence to
-                                      topologies that would help reduce the   skew.
-                                      A constraint is considered "Unsatisfiable" for
-                                      an incoming pod if and only if every possible
-                                      node assigment for that pod would violate "MaxSkew"
-                                      on some topology. For example, in a 3-zone cluster,
-                                      MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1: | zone1 | zone2
-                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
-                                      is set to DoNotSchedule, incoming pod can only
-                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                                      as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can
-                                      still be imbalanced, but scheduler won''t make
-                                      it *more* imbalanced. It''s a required field.'
+                                    description: WhenUnsatisfiable indicates how to
+                                      deal with a pod if it doesn't satisfy the spread
+                                      constraint.
                                     type: string
                                 required:
                                 - maxSkew
@@ -11683,49 +8785,36 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by
-                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: List of volumes that can be mounted by
+                                containers belonging to the pod.
                               items:
                                 description: Volume represents a named volume in a
                                   pod that may be accessed by any container in the
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents
-                                      an AWS Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: AWSElasticBlockStore represents an
+                                      AWS Disk resource that is attached to a kubelet's
+                                      host machine an
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: Filesystem type of the volume
+                                          that you want to mount.
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty).'
+                                        description: The partition in the volume that
+                                          you want to mount.
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and
-                                          set the ReadOnly property in VolumeMounts
-                                          to "true". If omitted, the default is "false".
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: Specify "true" to force and set
+                                          the ReadOnly property in VolumeMounts to
+                                          "true".
                                         type: boolean
                                       volumeID:
                                         description: 'Unique ID of the persistent
                                           disk resource in AWS (Amazon EBS volume).
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          More info: https://kubernetes.'
                                         type: string
                                     required:
                                     - volumeID
@@ -11750,15 +8839,12 @@ spec:
                                       fsType:
                                         description: Filesystem type to mount. Must
                                           be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                          operating system. Ex.
                                         type: string
                                       kind:
                                         description: 'Expected values Shared: multiple
                                           blob disks per storage account  Dedicated:
-                                          single blob disk per storage account  Managed:
-                                          azure managed data disk (only in managed
-                                          availability set). defaults to shared'
+                                          single blob disk per sto'
                                         type: string
                                       readOnly:
                                         description: Defaults to false (read/write).
@@ -11796,7 +8882,7 @@ spec:
                                     properties:
                                       monitors:
                                         description: 'Required: Monitors is a collection
-                                          of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          of Ceph monitors More info: https://examples.k8s.'
                                         items:
                                           type: string
                                         type: array
@@ -11807,51 +8893,41 @@ spec:
                                         type: string
                                       readOnly:
                                         description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          (read/write).'
                                         type: boolean
                                       secretFile:
                                         description: 'Optional: SecretFile is the
-                                          path to key ring for User, default is /etc/ceph/user.secret
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          path to key ring for User, default is /etc/ceph/user.'
                                         type: string
                                       secretRef:
                                         description: 'Optional: SecretRef is reference
                                           to the authentication secret for User, default
-                                          is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          is empty.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       user:
                                         description: 'Optional: User is the rados
-                                          user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          user name, default is admin More info: https://examples.k8s.'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume
+                                    description: Cinder represents a cinder volume
                                       attached and mounted on kubelets host machine.
-                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
+                                        description: Filesystem type to mount. Must
                                           be a filesystem type supported by the host
-                                          operating system. Examples: "ext4", "xfs",
-                                          "ntfs". Implicitly inferred to be "ext4"
-                                          if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          operating system.
                                         type: string
                                       readOnly:
                                         description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          (read/write).'
                                         type: boolean
                                       secretRef:
                                         description: 'Optional: points to a secret
@@ -11860,14 +8936,12 @@ spec:
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       volumeID:
                                         description: 'volume id used to identify the
-                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          volume in cinder. More info: https://examples.k8s.'
                                         type: string
                                     required:
                                     - volumeID
@@ -11878,31 +8952,13 @@ spec:
                                     properties:
                                       defaultMode:
                                         description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                          set permissions on created files by default.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: 'If unspecified, each key-value
                                           pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
+                                          ConfigMap will be projected '
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -11912,25 +8968,13 @@ spec:
                                               type: string
                                             mode:
                                               description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                to set permissions on this file.'
                                               format: int32
                                               type: integer
                                             path:
                                               description: The relative path of the
                                                 file to map the key to. May not be
-                                                an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                                an absolute path.
                                               type: string
                                           required:
                                           - key
@@ -11939,9 +8983,7 @@ spec:
                                         type: array
                                       name:
                                         description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                          https://kubernetes.'
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -11951,36 +8993,24 @@ spec:
                                   csi:
                                     description: CSI (Container Storage Interface)
                                       represents ephemeral storage that is handled
-                                      by certain external CSI drivers (Beta feature).
+                                      by certain external C
                                     properties:
                                       driver:
                                         description: Driver is the name of the CSI
-                                          driver that handles this volume. Consult
-                                          with your admin for the correct name as
-                                          registered in the cluster.
+                                          driver that handles this volume.
                                         type: string
                                       fsType:
                                         description: Filesystem type to mount. Ex.
-                                          "ext4", "xfs", "ntfs". If not provided,
-                                          the empty value is passed to the associated
-                                          CSI driver which will determine the default
-                                          filesystem to apply.
+                                          "ext4", "xfs", "ntfs".
                                         type: string
                                       nodePublishSecretRef:
                                         description: NodePublishSecretRef is a reference
                                           to the secret object containing sensitive
-                                          information to pass to the CSI driver to
-                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
-                                          calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                          information to pass to
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       readOnly:
@@ -11992,8 +9022,6 @@ spec:
                                           type: string
                                         description: VolumeAttributes stores driver-specific
                                           properties that are passed to the CSI driver.
-                                          Consult your driver's documentation for
-                                          supported values.
                                         type: object
                                     required:
                                     - driver
@@ -12004,18 +9032,7 @@ spec:
                                     properties:
                                       defaultMode:
                                         description: 'Optional: mode bits to use on
-                                          created files by default. Must be a Optional:
-                                          mode bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          created files by default.'
                                         format: int32
                                         type: integer
                                       items:
@@ -12047,31 +9064,18 @@ spec:
                                               description: 'Optional: mode bits used
                                                 to set permissions on this file, must
                                                 be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                07'
                                               format: int32
                                               type: integer
                                             path:
                                               description: 'Required: Path is  the
                                                 relative path name of the file to
-                                                be created. Must not be absolute or
-                                                contain the ''..'' path. Must be utf-8
-                                                encoded. The first item of the relative
-                                                path must not start with ''..'''
+                                                be created.'
                                               type: string
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
+                                                and requests (limits.cpu, limits.'
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -12100,141 +9104,59 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary
-                                      directory that shares a pod''s lifetime. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: EmptyDir represents a temporary directory
+                                      that shares a pod's lifetime.
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium
-                                          should back this directory. The default
-                                          is "" which means to use the node''s default
-                                          medium. Must be an empty string (default)
-                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: What type of storage medium should
+                                          back this directory.
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage
-                                          required for this EmptyDir volume. The size
-                                          limit is also applicable for memory medium.
-                                          The maximum usage on memory medium EmptyDir
-                                          would be the minimum value between the SizeLimit
-                                          specified here and the sum of memory limits
-                                          of all containers in a pod. The default
-                                          is nil which means that the limit is undefined.
-                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        description: Total amount of local storage
+                                          required for this EmptyDir volume.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "Ephemeral represents a volume that
+                                    description: Ephemeral represents a volume that
                                       is handled by a cluster storage driver (Alpha
-                                      feature). The volume's lifecycle is tied to
-                                      the pod that defines it - it will be created
-                                      before the pod starts, and deleted when the
-                                      pod is removed. \n Use this if: a) the volume
-                                      is only needed while the pod runs, b) features
-                                      of normal volumes like restoring from snapshot
-                                      or capacity    tracking are needed, c) the storage
-                                      driver is specified through a storage class,
-                                      and d) the storage driver supports dynamic volume
-                                      provisioning through    a PersistentVolumeClaim
-                                      (see EphemeralVolumeSource for more    information
-                                      on the connection between this volume type    and
-                                      PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                      or one of the vendor-specific APIs for volumes
-                                      that persist for longer than the lifecycle of
-                                      an individual pod. \n Use CSI for light-weight
-                                      local ephemeral volumes if the CSI driver is
-                                      meant to be used that way - see the documentation
-                                      of the driver for more information. \n A pod
-                                      can use both types of ephemeral volumes and
-                                      persistent volumes at the same time."
+                                      feature).
                                     properties:
                                       readOnly:
                                         description: Specifies a read-only configuration
                                           for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeClaimTemplate:
-                                        description: "Will be used to create a stand-alone
-                                          PVC to provision the volume. The pod in
-                                          which this EphemeralVolumeSource is embedded
-                                          will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
-                                          Pod validation will reject the pod if the
-                                          concatenated name is not valid for a PVC
-                                          (for example, too long). \n An existing
-                                          PVC with that name that is not owned by
-                                          the pod will *not* be used for the pod to
-                                          avoid using an unrelated volume by mistake.
-                                          Starting the pod is then blocked until the
-                                          unrelated PVC is removed. If such a pre-created
-                                          PVC is meant to be used by the pod, the
-                                          PVC has to updated with an owner reference
-                                          to the pod once the pod exists. Normally
-                                          this should not be necessary, but it may
-                                          be useful when manually reconstructing a
-                                          broken cluster. \n This field is read-only
-                                          and no changes will be made by Kubernetes
-                                          to the PVC after it has been created. \n
-                                          Required, must not be nil."
+                                        description: Will be used to create a stand-alone
+                                          PVC to provision the volume.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
                                               that will be copied into the PVC when
-                                              creating it. No other fields are allowed
-                                              and will be rejected during validation.
+                                              creating it.
                                             type: object
                                           spec:
                                             description: The specification for the
-                                              PersistentVolumeClaim. The entire content
-                                              is copied unchanged into the PVC that
-                                              gets created from this template. The
-                                              same fields as in a PersistentVolumeClaim
-                                              are also valid here.
+                                              PersistentVolumeClaim.
                                             properties:
                                               accessModes:
                                                 description: 'AccessModes contains
                                                   the desired access modes the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  should have. More info: https://kubernetes.'
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
                                                 description: 'This field can be used
                                                   to specify either: * An existing
-                                                  VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                                  * An existing custom resource/object
-                                                  that implements data population
-                                                  (Alpha) In order to use VolumeSnapshot
-                                                  object types, the appropriate feature
-                                                  gate must be enabled (VolumeSnapshotDataSource
-                                                  or AnyVolumeDataSource) If the provisioner
-                                                  or an external controller can support
-                                                  the specified data source, it will
-                                                  create a new volume based on the
-                                                  contents of the specified data source.
-                                                  If the specified data source is
-                                                  not supported, the volume will not
-                                                  be created and the failure will
-                                                  be reported as an event. In the
-                                                  future, we plan to support more
-                                                  data source types and the behavior
-                                                  of the provisioner may change.'
+                                                  VolumeSnapshot object (snapshot.storage.k8s.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
                                                       for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -12251,7 +9173,7 @@ spec:
                                               resources:
                                                 description: 'Resources represents
                                                   the minimum resources the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  should have. More info: https://kubernetes.'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -12263,7 +9185,7 @@ spec:
                                                     description: 'Limits describes
                                                       the maximum amount of compute
                                                       resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      https://kubernetes.'
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -12272,14 +9194,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Requests describes
+                                                    description: Requests describes
                                                       the minimum amount of compute
-                                                      resources required. If Requests
-                                                      is omitted for a container,
-                                                      it defaults to Limits if that
-                                                      is explicitly specified, otherwise
-                                                      to an implementation-defined
-                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      resources required.
                                                     type: object
                                                 type: object
                                               selector:
@@ -12296,7 +9213,6 @@ spec:
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
-                                                        the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -12306,21 +9222,11 @@ spec:
                                                         operator:
                                                           description: operator represents
                                                             a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                            a set of values.
                                                           type: string
                                                         values:
                                                           description: values is an
                                                             array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -12333,26 +9239,18 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                      map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                               storageClassName:
                                                 description: 'Name of the StorageClass
                                                   required by the claim. More info:
-                                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  https://kubernetes.'
                                                 type: string
                                               volumeMode:
                                                 description: volumeMode defines what
                                                   type of volume is required by the
-                                                  claim. Value of Filesystem is implied
-                                                  when not included in claim spec.
+                                                  claim.
                                                 type: string
                                               volumeName:
                                                 description: VolumeName is the binding
@@ -12367,15 +9265,12 @@ spec:
                                   fc:
                                     description: FC represents a Fibre Channel resource
                                       that is attached to a kubelet's host machine
-                                      and then exposed to the pod.
+                                      and then exposed
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
+                                        description: Filesystem type to mount. Must
                                           be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          operating system. Ex.
                                         type: string
                                       lun:
                                         description: 'Optional: FC target lun number'
@@ -12383,8 +9278,7 @@ spec:
                                         type: integer
                                       readOnly:
                                         description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                          (read/write).'
                                         type: boolean
                                       targetWWNs:
                                         description: 'Optional: FC target worldwide
@@ -12395,8 +9289,7 @@ spec:
                                       wwids:
                                         description: 'Optional: FC volume world wide
                                           identifiers (wwids) Either wwids or combination
-                                          of targetWWNs and lun must be set, but not
-                                          both simultaneously.'
+                                          of targetWWNs and lun'
                                         items:
                                           type: string
                                         type: array
@@ -12404,7 +9297,7 @@ spec:
                                   flexVolume:
                                     description: FlexVolume represents a generic volume
                                       resource that is provisioned/attached using
-                                      an exec based plugin.
+                                      an exec based plu
                                     properties:
                                       driver:
                                         description: Driver is the name of the driver
@@ -12413,9 +9306,7 @@ spec:
                                       fsType:
                                         description: Filesystem type to mount. Must
                                           be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          The default filesystem depends on FlexVolume
-                                          script.
+                                          operating system. Ex.
                                         type: string
                                       options:
                                         additionalProperties:
@@ -12425,23 +9316,16 @@ spec:
                                         type: object
                                       readOnly:
                                         description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                          (read/write).'
                                         type: boolean
                                       secretRef:
                                         description: 'Optional: SecretRef is reference
                                           to the secret object containing sensitive
-                                          information to pass to the plugin scripts.
-                                          This may be empty if no secret object is
-                                          specified. If the secret object contains
-                                          more than one secret, all secrets are passed
-                                          to the plugin scripts.'
+                                          information to pass to th'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                     required:
@@ -12449,13 +9333,12 @@ spec:
                                     type: object
                                   flocker:
                                     description: Flocker represents a Flocker volume
-                                      attached to a kubelet's host machine. This depends
-                                      on the Flocker control service being running
+                                      attached to a kubelet's host machine.
                                     properties:
                                       datasetName:
                                         description: Name of the dataset stored as
                                           metadata -> name on the dataset for Flocker
-                                          should be considered as deprecated
+                                          should be considered as de
                                         type: string
                                       datasetUUID:
                                         description: UUID of the dataset. This is
@@ -12463,40 +9346,27 @@ spec:
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE
-                                      Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: GCEPersistentDisk represents a GCE
+                                      Disk resource that is attached to a kubelet's
+                                      host machine and th
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: Filesystem type of the volume
+                                          that you want to mount.
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: The partition in the volume that
+                                          you want to mount.
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource
+                                        description: Unique name of the PD resource
                                           in GCE. Used to identify the disk in GCE.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: ReadOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          to false.
                                         type: boolean
                                     required:
                                     - pdName
@@ -12504,18 +9374,11 @@ spec:
                                   gitRepo:
                                     description: 'GitRepo represents a git repository
                                       at a particular revision. DEPRECATED: GitRepo
-                                      is deprecated. To provision a container with
-                                      a git repo, mount an EmptyDir into an InitContainer
-                                      that clones the repo using git, then mount the
-                                      EmptyDir into the Pod''s container.'
+                                      is deprecated.'
                                     properties:
                                       directory:
                                         description: Target directory name. Must not
-                                          contain or start with '..'.  If '.' is supplied,
-                                          the volume directory will be the git repository.  Otherwise,
-                                          if specified, the volume will contain the
-                                          git repository in the subdirectory with
-                                          the given name.
+                                          contain or start with '..'.  If '.
                                         type: string
                                       repository:
                                         description: Repository URL
@@ -12528,57 +9391,47 @@ spec:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    description: Glusterfs represents a Glusterfs
+                                      mount on the host that shares a pod's lifetime.
                                     properties:
                                       endpoints:
                                         description: 'EndpointsName is the endpoint
                                           name that details Glusterfs topology. More
-                                          info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          info: https://examples.k8s.'
                                         type: string
                                       path:
                                         description: 'Path is the Glusterfs volume
-                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: ReadOnly here will force the
                                           Glusterfs volume to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          permissions.
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing
+                                    description: HostPath represents a pre-existing
                                       file or directory on the host machine that is
-                                      directly exposed to the container. This is generally
-                                      used for system agents or other privileged things
-                                      that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                      --- TODO(jonesdl) We need to restrict who can
-                                      use host directory mounts and who can/can not
-                                      mount host directories as read/write.'
+                                      directly exposed to
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the
-                                          host. If the path is a symlink, it will
-                                          follow the link to the real path. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: Path of the directory on the
+                                          host.
                                         type: string
                                       type:
                                         description: 'Type for HostPath Volume Defaults
-                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          to "" More info: https://kubernetes.'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource
-                                      that is attached to a kubelet''s host machine
-                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    description: ISCSI represents an ISCSI Disk resource
+                                      that is attached to a kubelet's host machine
+                                      and then expose
                                     properties:
                                       chapAuthDiscovery:
                                         description: whether support iSCSI Discovery
@@ -12589,21 +9442,11 @@ spec:
                                           CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: Filesystem type of the volume
+                                          that you want to mount.
                                         type: string
                                       initiatorName:
                                         description: Custom iSCSI Initiator Name.
-                                          If initiatorName is specified with iscsiInterface
-                                          simultaneously, new iSCSI interface <target
-                                          portal>:<volume name> will be created for
-                                          the connection.
                                         type: string
                                       iqn:
                                         description: Target iSCSI Qualified Name.
@@ -12618,10 +9461,7 @@ spec:
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The
-                                          portal is either an IP or ip_addr:port if
-                                          the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: iSCSI Target Portal List.
                                         items:
                                           type: string
                                         type: array
@@ -12636,16 +9476,11 @@ spec:
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal
-                                          is either an IP or ip_addr:port if the port
-                                          is other than default (typically TCP ports
-                                          860 and 3260).
+                                        description: iSCSI Target Portal.
                                         type: string
                                     required:
                                     - iqn
@@ -12654,40 +9489,39 @@ spec:
                                     type: object
                                   name:
                                     description: 'Volume''s name. Must be a DNS_LABEL
-                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      and unique within the pod. More info: https://kubernetes.'
                                     type: string
                                   nfs:
                                     description: 'NFS represents an NFS mount on the
                                       host that shares a pod''s lifetime More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      https://kubernetes.'
                                     properties:
                                       path:
                                         description: 'Path that is exported by the
-                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          NFS server. More info: https://kubernetes.'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: ReadOnly here will force the
                                           NFS export to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          permissions. Defaults to false.
                                         type: boolean
                                       server:
                                         description: 'Server is the hostname or IP
-                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          address of the NFS server. More info: https://kubernetes.'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource
+                                    description: PersistentVolumeClaimVolumeSource
                                       represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      in the same name
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                        description: ClaimName is the name of a PersistentVolumeClaim
                                           in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          volume.
                                         type: string
                                       readOnly:
                                         description: Will force the ReadOnly setting
@@ -12697,15 +9531,14 @@ spec:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a
-                                      PhotonController persistent disk attached and
-                                      mounted on kubelets host machine
+                                    description: 'PhotonPersistentDisk represents
+                                      a PhotonController persistent disk attached
+                                      and mounted on kubelets '
                                     properties:
                                       fsType:
                                         description: Filesystem type to mount. Must
                                           be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                          operating system. Ex.
                                         type: string
                                       pdID:
                                         description: ID that identifies Photon Controller
@@ -12722,9 +9555,7 @@ spec:
                                       fsType:
                                         description: FSType represents the filesystem
                                           type to mount Must be a filesystem type
-                                          supported by the host operating system.
-                                          Ex. "ext4", "xfs". Implicitly inferred to
-                                          be "ext4" if unspecified.
+                                          supported by the host opera
                                         type: string
                                       readOnly:
                                         description: Defaults to false (read/write).
@@ -12744,16 +9575,7 @@ spec:
                                     properties:
                                       defaultMode:
                                         description: Mode bits used to set permissions
-                                          on created files by default. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. Directories
-                                          within the path are not affected by this
-                                          setting. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.
+                                          on created files by default.
                                         format: int32
                                         type: integer
                                       sources:
@@ -12767,21 +9589,10 @@ spec:
                                                 data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
+                                                  description: 'If unspecified, each
                                                     key-value pair in the Data field
                                                     of the referenced ConfigMap will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the ConfigMap,
-                                                    the volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
+                                                    be projected '
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -12792,30 +9603,14 @@ spec:
                                                       mode:
                                                         description: 'Optional: mode
                                                           bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          on this file.'
                                                         format: int32
                                                         type: integer
                                                       path:
                                                         description: The relative
                                                           path of the file to map
                                                           the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                          absolute path.
                                                         type: string
                                                     required:
                                                     - key
@@ -12824,9 +9619,7 @@ spec:
                                                   type: array
                                                 name:
                                                   description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -12872,38 +9665,19 @@ spec:
                                                           bits used to set permissions
                                                           on this file, must be an
                                                           octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          and 07'
                                                         format: int32
                                                         type: integer
                                                       path:
                                                         description: 'Required: Path
                                                           is  the relative path name
-                                                          of the file to be created.
-                                                          Must not be absolute or
-                                                          contain the ''..'' path.
-                                                          Must be utf-8 encoded. The
-                                                          first item of the relative
-                                                          path must not start with
-                                                          ''..'''
+                                                          of the file to be created.'
                                                         type: string
                                                       resourceFieldRef:
                                                         description: 'Selects a resource
                                                           of the container: only resources
                                                           limits and requests (limits.cpu,
-                                                          limits.memory, requests.cpu
-                                                          and requests.memory) are
-                                                          currently supported.'
+                                                          limits.'
                                                         properties:
                                                           containerName:
                                                             description: 'Container
@@ -12940,18 +9714,7 @@ spec:
                                                   description: If unspecified, each
                                                     key-value pair in the Data field
                                                     of the referenced Secret will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the Secret, the
-                                                    volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
+                                                    be projected int
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -12962,30 +9725,14 @@ spec:
                                                       mode:
                                                         description: 'Optional: mode
                                                           bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          on this file.'
                                                         format: int32
                                                         type: integer
                                                       path:
                                                         description: The relative
                                                           path of the file to map
                                                           the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                          absolute path.
                                                         type: string
                                                     required:
                                                     - key
@@ -12994,9 +9741,7 @@ spec:
                                                   type: array
                                                 name:
                                                   description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -13009,28 +9754,12 @@ spec:
                                               properties:
                                                 audience:
                                                   description: Audience is the intended
-                                                    audience of the token. A recipient
-                                                    of a token must identify itself
-                                                    with an identifier specified in
-                                                    the audience of the token, and
-                                                    otherwise should reject the token.
-                                                    The audience defaults to the identifier
-                                                    of the apiserver.
+                                                    audience of the token.
                                                   type: string
                                                 expirationSeconds:
                                                   description: ExpirationSeconds is
                                                     the requested duration of validity
                                                     of the service account token.
-                                                    As the token approaches expiration,
-                                                    the kubelet volume plugin will
-                                                    proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -13057,20 +9786,17 @@ spec:
                                       readOnly:
                                         description: ReadOnly here will force the
                                           Quobyte volume to be mounted with read-only
-                                          permissions. Defaults to false.
+                                          permissions.
                                         type: boolean
                                       registry:
                                         description: Registry represents a single
                                           or multiple Quobyte Registry services specified
-                                          as a string as host:port pair (multiple
-                                          entries are separated with commas) which
-                                          acts as the central registry for volumes
+                                          as a string as host:por
                                         type: string
                                       tenant:
                                         description: Tenant owning the given Quobyte
                                           volume in the Backend Used with dynamically
-                                          provisioned Quobyte volumes, value is set
-                                          by the plugin
+                                          provisioned Quobyte volu
                                         type: string
                                       user:
                                         description: User to map volume access to
@@ -13085,59 +9811,49 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    description: RBD represents a Rados Block Device
+                                      mount on the host that shares a pod's lifetime.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: Filesystem type of the volume
+                                          that you want to mount.
                                         type: string
                                       image:
                                         description: 'The rados image name. More info:
                                           https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring
+                                        description: Keyring is the path to key ring
                                           for RBDUser. Default is /etc/ceph/keyring.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
                                         description: 'A collection of Ceph monitors.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          More info: https://examples.k8s.io/volumes/rbd/README.'
                                         items:
                                           type: string
                                         type: array
                                       pool:
                                         description: 'The rados pool name. Default
-                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: ReadOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          to false.
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication
+                                        description: SecretRef is name of the authentication
                                           secret for RBDUser. If provided overrides
-                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          keyring.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       user:
                                         description: 'The rados user name. Default
-                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.'
                                         type: string
                                     required:
                                     - image
@@ -13150,8 +9866,7 @@ spec:
                                       fsType:
                                         description: Filesystem type to mount. Must
                                           be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Default is "xfs".
+                                          operating system. Ex.
                                         type: string
                                       gateway:
                                         description: The host address of the ScaleIO
@@ -13169,14 +9884,10 @@ spec:
                                       secretRef:
                                         description: SecretRef references to the secret
                                           for ScaleIO user and other sensitive information.
-                                          If this is not provided, Login operation
-                                          will fail.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       sslEnabled:
@@ -13186,7 +9897,7 @@ spec:
                                       storageMode:
                                         description: Indicates whether the storage
                                           for a volume should be ThickProvisioned
-                                          or ThinProvisioned. Default is ThinProvisioned.
+                                          or ThinProvisioned.
                                         type: string
                                       storagePool:
                                         description: The ScaleIO Storage Pool associated
@@ -13199,7 +9910,7 @@ spec:
                                       volumeName:
                                         description: The name of a volume already
                                           created in the ScaleIO system that is associated
-                                          with this volume source.
+                                          with this volume sourc
                                         type: string
                                     required:
                                     - gateway
@@ -13208,35 +9919,17 @@ spec:
                                     type: object
                                   secret:
                                     description: 'Secret represents a secret that
-                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      should populate this volume. More info: https://kubernetes.'
                                     properties:
                                       defaultMode:
                                         description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                          set permissions on created files by default.'
                                         format: int32
                                         type: integer
                                       items:
                                         description: If unspecified, each key-value
                                           pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
+                                          Secret will be projected int
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -13246,25 +9939,13 @@ spec:
                                               type: string
                                             mode:
                                               description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                to set permissions on this file.'
                                               format: int32
                                               type: integer
                                             path:
                                               description: The relative path of the
                                                 file to map the key to. May not be
-                                                an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                                an absolute path.
                                               type: string
                                           required:
                                           - key
@@ -13277,7 +9958,7 @@ spec:
                                         type: boolean
                                       secretName:
                                         description: 'Name of the secret in the pod''s
-                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          namespace to use. More info: https://kubernetes.'
                                         type: string
                                     type: object
                                   storageos:
@@ -13287,8 +9968,7 @@ spec:
                                       fsType:
                                         description: Filesystem type to mount. Must
                                           be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                          operating system. Ex.
                                         type: string
                                       readOnly:
                                         description: Defaults to false (read/write).
@@ -13297,32 +9977,20 @@ spec:
                                         type: boolean
                                       secretRef:
                                         description: SecretRef specifies the secret
-                                          to use for obtaining the StorageOS API credentials.  If
-                                          not specified, default values will be attempted.
+                                          to use for obtaining the StorageOS API credentials.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       volumeName:
                                         description: VolumeName is the human-readable
-                                          name of the StorageOS volume.  Volume names
-                                          are only unique within a namespace.
+                                          name of the StorageOS volume.
                                         type: string
                                       volumeNamespace:
                                         description: VolumeNamespace specifies the
-                                          scope of the volume within StorageOS.  If
-                                          no namespace is specified then the Pod's
-                                          namespace will be used.  This allows the
-                                          Kubernetes name scoping to be mirrored within
-                                          StorageOS for tighter integration. Set VolumeName
-                                          to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS. Namespaces that do not
-                                          pre-exist within StorageOS will be created.
+                                          scope of the volume within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:
@@ -13333,8 +10001,7 @@ spec:
                                       fsType:
                                         description: Filesystem type to mount. Must
                                           be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                          operating system. Ex.
                                         type: string
                                       storagePolicyID:
                                         description: Storage Policy Based Management
@@ -13401,8 +10068,7 @@ spec:
                 type: integer
               state:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file The overall state of the Ray cluster.'
+                  of cluster Important: Run "make" to regenerat'
                 type: string
             type: object
         type: object

--- a/bytedance/config/manager/controller_manager_config.yaml
+++ b/bytedance/config/manager/controller_manager_config.yaml
@@ -8,4 +8,4 @@ webhook:
   port: 9443
 leaderElection:
   leaderElect: true
-  resourceName: 6adafd3f.
+  resourceName: 6adafd3f


### PR DESCRIPTION
1.  Fix leader election failure that controller can not start with `--leader-elect`
2. Fix CRD too long issue. This is a known issue. See https://github.com/kubernetes-sigs/kubebuilder/issues/1140 for more details
3. Add README.md and CONTRIBUTING.md