### PR TITLE
Upgrade to go 1.15

### DIFF
--- a/msft-operator/ray-operator/Dockerfile
+++ b/msft-operator/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.12.5 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Building `msft-operator` with current `Dockerfile` gives the error:

```
go: error loading module requirements
```

Upgrading from go 1.12 to 1.15 resolves the issue.