### PR TITLE
Alkanso/remove block

### DIFF
--- a/msft-operator/ray-operator/Makefile
+++ b/msft-operator/ray-operator/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ray-controller:latest
+IMG ?= bonsaidev.azurecr.io/bonsai/rayoperator:0.1.0 # bonsaidev.azurecr.io/bonsaidev:0.1.0
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/msft-operator/ray-operator/Makefile
+++ b/msft-operator/ray-operator/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= bonsaidev.azurecr.io/bonsai/rayoperator:0.1.0 # bonsaidev.azurecr.io/bonsaidev:0.1.0
+IMG ?= ray-controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/msft-operator/ray-operator/controllers/common/pod.go
+++ b/msft-operator/ray-operator/controllers/common/pod.go
@@ -19,6 +19,7 @@ var log = logf.Log.WithName("RayCluster-Controller")
 
 const (
 	defaultServiceAccountName = "default"
+	HeadGroup                 = "headgroup"
 )
 
 // PodConfig contains pod config
@@ -43,7 +44,7 @@ func DefaultHeadPodConfig(instance rayiov1alpha1.RayCluster, rayNodeType rayiov1
 	if pConfig.podTemplate.Labels == nil {
 		pConfig.podTemplate.Labels = make(map[string]string)
 	}
-	pConfig.podTemplate.Labels = labelPod(string(rayiov1alpha1.HeadNode), instance.Name, "headGroup", instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
+	pConfig.podTemplate.Labels = labelPod(string(rayiov1alpha1.HeadNode), instance.Name, HeadGroup, instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
 
 	if pConfig.podTemplate.ObjectMeta.Namespace == "" {
 		pConfig.podTemplate.ObjectMeta.Namespace = instance.Namespace

--- a/msft-operator/ray-operator/controllers/common/pod.go
+++ b/msft-operator/ray-operator/controllers/common/pod.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	rayiov1alpha1 "ray-operator/api/v1alpha1"
+	"ray-operator/controllers/utils"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -162,7 +163,7 @@ func labelPod(rayNodeType string, rayClusterName string, groupName string, label
 		"rayClusterName": rayClusterName,
 		"rayNodeType":    rayNodeType,
 		"groupName":      groupName,
-		"identifier":     fmt.Sprintf("%s-%s", rayClusterName, rayNodeType),
+		"identifier":     utils.TrimName(fmt.Sprintf("%s-%s", rayClusterName, rayNodeType)),
 	}
 
 	for k, v := range ret {
@@ -271,7 +272,7 @@ func concatinateContainerCommand(nodeType rayiov1alpha1.RayNodeType, rayStartPar
 	case rayiov1alpha1.HeadNode:
 		return fmt.Sprintf("ulimit -n 65536; ray start --head %s", convertParamMap(rayStartParams))
 	case rayiov1alpha1.WorkerNode:
-		return fmt.Sprintf("ulimit -n 65536; ray start --block %s", convertParamMap(rayStartParams))
+		return fmt.Sprintf("ulimit -n 65536; ray start %s", convertParamMap(rayStartParams))
 	default:
 		log.Error(fmt.Errorf("missing node type"), "a node must be either head or worker")
 	}

--- a/msft-operator/ray-operator/controllers/common/service.go
+++ b/msft-operator/ray-operator/controllers/common/service.go
@@ -48,8 +48,8 @@ func BuildServiceForHeadPod(instance rayiov1alpha1.RayCluster) *corev1.Service {
 // checkServiceName verfies that we prefix the Ray cluster name to the service name
 // this avoid having service conflicts in case two  Ray clusters define the same service name
 func checkSvcName(instance rayiov1alpha1.RayCluster) (name string) {
-	if !strings.HasPrefix(instance.Spec.HeadService.Name, instance.Name) {
-		amendedName := fmt.Sprintf("%s-%s", instance.Name, instance.Spec.HeadService.Name)
+	if !strings.HasPrefix(instance.Spec.HeadService.Name, fmt.Sprintf("%s-%s", "svc", instance.Name)) {
+		amendedName := fmt.Sprintf("%s-%s-%s", "svc", instance.Name, instance.Spec.HeadService.Name)
 		amendedName = utils.TrimName(amendedName)
 		errorList, nameIsValid := utils.IsValid(amendedName)
 		if !nameIsValid {
@@ -58,5 +58,5 @@ func checkSvcName(instance rayiov1alpha1.RayCluster) (name string) {
 		log.Info("checkSvcName ", "svc name amended", amendedName)
 		return amendedName
 	}
-	return utils.TrimName(instance.Spec.HeadService.Name)
+	return utils.TrimName(fmt.Sprintf("%s-%s", "svc", instance.Spec.HeadService.Name))
 }

--- a/msft-operator/ray-operator/controllers/common/service_test.go
+++ b/msft-operator/ray-operator/controllers/common/service_test.go
@@ -88,7 +88,7 @@ func TestBuildServiceForHeadPod(t *testing.T) {
 
 func TestCheckSvcName(t *testing.T) {
 	instanceWithWrongSvc.Name = "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director-head"
-	expectedResult := "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-di"
+	expectedResult := "svc-f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090schola"
 	svcName := checkSvcName(*instanceWithWrongSvc)
 	if len(svcName) > 55 {
 		t.Fail()

--- a/msft-operator/ray-operator/controllers/common/service_test.go
+++ b/msft-operator/ray-operator/controllers/common/service_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	rayiov1alpha1 "ray-operator/api/v1alpha1"
+	"ray-operator/controllers/utils"
 	"reflect"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 
 var instanceWithWrongSvc = &rayiov1alpha1.RayCluster{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      "raycluster-sample",
+		Name:      "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director",
 		Namespace: "default",
 	},
 	Spec: rayiov1alpha1.RayClusterSpec{
@@ -79,8 +80,20 @@ func TestBuildServiceForHeadPod(t *testing.T) {
 	svc := BuildServiceForHeadPod(*instanceWithWrongSvc)
 
 	actualResult := svc.Spec.Selector["identifier"]
-	expectedResult := fmt.Sprintf("%s-%s", instanceWithWrongSvc.Name, rayiov1alpha1.HeadNode)
+	expectedResult := utils.TrimName(fmt.Sprintf("%s-%s", instanceWithWrongSvc.Name, rayiov1alpha1.HeadNode))
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
+	}
+}
+
+func TestCheckSvcName(t *testing.T) {
+	instanceWithWrongSvc.Name = "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director-head"
+	expectedResult := "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-di"
+	svcName := checkSvcName(*instanceWithWrongSvc)
+	if len(svcName) > 55 {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(expectedResult, svcName) {
+		t.Fatalf("Expected `%v` but got `%v`", expectedResult, svcName)
 	}
 }

--- a/msft-operator/ray-operator/controllers/raycluster_controller.go
+++ b/msft-operator/ray-operator/controllers/raycluster_controller.go
@@ -105,7 +105,8 @@ func (r *RayClusterReconciler) checkPods(instance *rayiov1alpha1.RayCluster, hea
 	//var updateNeeded bool
 	// check if all the pods exist
 	headPods := corev1.PodList{}
-	if err := r.List(context.TODO(), &headPods, client.InNamespace(instance.Namespace), client.MatchingLabels{"rayClusterName": instance.Name, "groupName": "headgroup"}); err != nil {
+	log.Info("checkPods ", "fetching head pods with labels", instance.Namespace, "rayClusterName", instance.Name, "groupName", common.HeadGroup)
+	if err := r.List(context.TODO(), &headPods, client.InNamespace(instance.Namespace), client.MatchingLabels{"rayClusterName": instance.Name, "groupName": common.HeadGroup}); err != nil {
 		return err
 	}
 	if len(headPods.Items) == 1 {
@@ -118,7 +119,7 @@ func (r *RayClusterReconciler) checkPods(instance *rayiov1alpha1.RayCluster, hea
 	}
 	if len(headPods.Items) == 0 || headPods.Items == nil {
 		// create head pod
-		log.Info("checkPods ", "creating head pod for cluster", instance.Name)
+		log.Info("checkPods ", "did not find any head pods in namespace", instance.Namespace, "creating head pod for cluster", instance.Name)
 		if err := r.createHeadPod(*instance, headSvcName); err != nil {
 			return err
 		}

--- a/msft-operator/ray-operator/controllers/raycluster_controller_test.go
+++ b/msft-operator/ray-operator/controllers/raycluster_controller_test.go
@@ -165,7 +165,7 @@ var _ = Context("Inside the default namespace", func() {
 		It("should create a new head service resource", func() {
 			svc := &corev1.Service{}
 			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: utils.TrimName("f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director-head-svc"), Namespace: "default"}, svc),
+				getResourceFunc(ctx, client.ObjectKey{Name: utils.TrimName("svc-f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director-head-svc"), Namespace: "default"}, svc),
 				time.Second*15, time.Millisecond*500).Should(BeNil(), "My head service = %v", svc)
 			Expect(svc.Spec.Selector["identifier"]).Should(Equal(utils.TrimName(fmt.Sprintf("%s-%s", myRayCluster.Name, rayiov1alpha1.HeadNode))))
 		})

--- a/msft-operator/ray-operator/controllers/raycluster_controller_test.go
+++ b/msft-operator/ray-operator/controllers/raycluster_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	rayiov1alpha1 "ray-operator/api/v1alpha1"
+	"ray-operator/controllers/utils"
 	"reflect"
 	"time"
 
@@ -42,7 +43,7 @@ var _ = Context("Inside the default namespace", func() {
 
 	var myRayCluster = &rayiov1alpha1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "raycluster-sample",
+			Name:      "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director",
 			Namespace: "default",
 		},
 		Spec: rayiov1alpha1.RayClusterSpec{
@@ -59,7 +60,7 @@ var _ = Context("Inside the default namespace", func() {
 					ClusterIP: corev1.ClusterIPNone,
 					// This selector must match the label of the head node.
 					Selector: map[string]string{
-						"identifier": "raycluster-sample-head",
+						"identifier": "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director-head",
 					},
 				},
 			},
@@ -77,7 +78,7 @@ var _ = Context("Inside the default namespace", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Labels: map[string]string{
-							"rayCluster": "raycluster-sample",
+							"rayCluster": "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director",
 							"groupName":  "headgroup",
 						},
 					},
@@ -118,7 +119,7 @@ var _ = Context("Inside the default namespace", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
 							Labels: map[string]string{
-								"rayCluster": "raycluster-sample",
+								"rayCluster": "f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director",
 								"groupName":  "small-group",
 							},
 						},
@@ -164,9 +165,9 @@ var _ = Context("Inside the default namespace", func() {
 		It("should create a new head service resource", func() {
 			svc := &corev1.Service{}
 			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: "raycluster-sample-head-svc", Namespace: "default"}, svc),
+				getResourceFunc(ctx, client.ObjectKey{Name: utils.TrimName("f14805df-6edb-06d9-e8e3-ecfd05c4c1ae-lazer090scholar-director-head-svc"), Namespace: "default"}, svc),
 				time.Second*15, time.Millisecond*500).Should(BeNil(), "My head service = %v", svc)
-			Expect(svc.Spec.Selector["identifier"]).Should(Equal(fmt.Sprintf("%s-%s", myRayCluster.Name, rayiov1alpha1.HeadNode)))
+			Expect(svc.Spec.Selector["identifier"]).Should(Equal(utils.TrimName(fmt.Sprintf("%s-%s", myRayCluster.Name, rayiov1alpha1.HeadNode))))
 		})
 
 		It("should create more than 1 worker", func() {

--- a/msft-operator/ray-operator/controllers/utils/util.go
+++ b/msft-operator/ray-operator/controllers/utils/util.go
@@ -6,7 +6,44 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	validation "k8s.io/apimachinery/pkg/util/validation"
 )
+
+const DashSymbol = "-"
+
+// IsValid returns true if name is valid
+func IsValid(name string) (errorList []string, notValid bool) {
+	return validation.IsQualifiedName(name), len(validation.IsQualifiedName(name)) == 0
+}
+
+// trimName shortens a name
+func TrimName(name string) string {
+	// leaving 8 extra characters up to the max allowed = 63
+	maxLength := 55
+	if len(name) > maxLength {
+		name = name[:maxLength]
+	}
+	name = strings.TrimSpace(name)
+	// remove last trailing dash(s)
+	for len(name) > 0 && name[len(name)-1:] == DashSymbol {
+		name = strings.TrimSuffix(name, DashSymbol)
+	}
+	// remove dash(s) at the begining
+	for len(name) > 0 && name[0:1] == DashSymbol {
+		name = strings.TrimPrefix(name, DashSymbol)
+	}
+	return name
+}
+
+func TrimMap(myMap map[string]string) map[string]string {
+	if myMap == nil {
+		return myMap
+	}
+	for key, element := range myMap {
+		myMap[key] = TrimName(element)
+	}
+	return myMap
+}
 
 // IsCreated returns true if pod has been created and is maintained by the API server
 func IsCreated(pod *corev1.Pod) bool {


### PR DESCRIPTION
This PR target s a couple of issues:
1- it removes the `--block` from the ray start command of the workers
2- it re-arranges the names of the pod, starting with `head` or `worker` followed by instance name
3- it validates the names making sure they are compliant with K8s regex
4- it trims names that are `> 63 char`, to avoid k8s create failure